### PR TITLE
로그인/회원가입 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chagok-fe",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.7.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2",
@@ -1469,6 +1470,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1556,6 +1574,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1628,6 +1658,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1983,6 +2022,40 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2261,6 +2334,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2452,6 +2546,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import styled, { createGlobalStyle, ThemeProvider } from "styled-components";
+import { createGlobalStyle, ThemeProvider } from "styled-components";
 import reset from "styled-reset";
 
 import { lightTheme } from "./configs/theme";
@@ -16,6 +16,7 @@ import ManageBudgetPage from "./pages/ManageBudgetPage";
 import StatsPage from "./pages/StatsPage";
 import LoginPage from "./pages/LoginPage";
 import JoinPage from "./pages/JoinPage";
+import AuthLayout from "./components/templates/AuthLayout";
 
 function App() {
   const [isLoading, setIsLoading] = useState(true);
@@ -31,10 +32,8 @@ function App() {
   return (
     <AuthProvider>
       <ThemeProvider theme={lightTheme}>
-        <Wrapper>
-          <GlobalStyles />
-          {isLoading ? <LoadingScreen /> : <RouterProvider router={router} />}
-        </Wrapper>
+        <GlobalStyles />
+        {isLoading ? <LoadingScreen /> : <RouterProvider router={router} />}
       </ThemeProvider>
     </AuthProvider>
   );
@@ -73,11 +72,19 @@ const router = createBrowserRouter([
   },
   {
     path: "/login",
-    element: <LoginPage />,
+    element: (
+      <AuthLayout>
+        <LoginPage />
+      </AuthLayout>
+    ),
   },
   {
     path: "/join",
-    element: <JoinPage />,
+    element: (
+      <AuthLayout>
+        <JoinPage />
+      </AuthLayout>
+    ),
   },
 ]);
 
@@ -92,12 +99,6 @@ const GlobalStyles = createGlobalStyle`
     color: ${({ theme }) => theme.text.primary};
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   }
-`;
-
-const Wrapper = styled.div`
-  height: 100vh;
-  display: flex;
-  justify-content: center;
 `;
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import { createGlobalStyle, ThemeProvider } from "styled-components";
+import styled, { createGlobalStyle, ThemeProvider } from "styled-components";
 import reset from "styled-reset";
 
 import { lightTheme } from "./configs/theme";
+import { AuthProvider } from "./contexts/auth";
 import LoadingScreen from "./components/organisms/LoadingScreen";
 import MainLayout from "./components/templates/MainLayout";
+import PrivateRoute from "./components/templates/PrivateRoute";
 
 import HomePage from "./pages/HomePage";
 import AddEntryPage from "./pages/AddEntryPage";
@@ -27,17 +29,25 @@ function App() {
   }, []);
 
   return (
-    <ThemeProvider theme={lightTheme}>
-      <GlobalStyles />
-      {isLoading ? <LoadingScreen /> : <RouterProvider router={router} />}
-    </ThemeProvider>
+    <AuthProvider>
+      <ThemeProvider theme={lightTheme}>
+        <Wrapper>
+          <GlobalStyles />
+          {isLoading ? <LoadingScreen /> : <RouterProvider router={router} />}
+        </Wrapper>
+      </ThemeProvider>
+    </AuthProvider>
   );
 }
 
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <MainLayout />,
+    element: (
+      <PrivateRoute>
+        <MainLayout />
+      </PrivateRoute>
+    ),
     children: [
       {
         path: "",
@@ -82,6 +92,12 @@ const GlobalStyles = createGlobalStyle`
     color: ${({ theme }) => theme.text.primary};
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   }
+`;
+
+const Wrapper = styled.div`
+  height: 100vh;
+  display: flex;
+  justify-content: center;
 `;
 
 export default App;

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -4,7 +4,6 @@ import axiosInstance from "./axiosInstance";
 
 const API_URL = "/auth";
 
-// 로그인 API 요청
 export const signInWithEmailAndPassword = async (
   email: string,
   password: string
@@ -23,7 +22,30 @@ export const signInWithEmailAndPassword = async (
       const { path, errorCode, detail, timestamp } = error.response.data;
       throw new ApiError(path, errorCode, detail, timestamp);
     }
-    throw new Error(`An unknown error occurred - ${API_URL}/sign-in`);
+    throw new Error(`Error: ${API_URL}/sign-in`);
+  }
+};
+
+export const signUpWithEmailAndPassword = async (
+  email: string,
+  password: string,
+  nickname: string
+) => {
+  try {
+    const response = await axiosInstance.post(
+      `${API_URL}/sign-up`,
+      { email, password, nickname },
+      { withCredentials: true }
+    );
+
+    const { data } = response.data;
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const { path, errorCode, detail, timestamp } = error.response.data;
+      throw new ApiError(path, errorCode, detail, timestamp);
+    }
+    throw new Error(`Error: ${API_URL}/sign-up`);
   }
 };
 
@@ -35,15 +57,6 @@ export const logout = async () => {
     {},
     { withCredentials: true }
   );
-  return response.data;
-};
-
-// 회원가입 API 요청
-export const register = async (email: string, password: string) => {
-  const response = await axiosInstance.post(`${API_URL}/register`, {
-    email,
-    password,
-  });
   return response.data;
 };
 */

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,49 @@
+import axios from "axios";
+import { ApiError } from "../types/errorTypes";
+import axiosInstance from "./axiosInstance";
+
+const API_URL = "/auth";
+
+// 로그인 API 요청
+export const signInWithEmailAndPassword = async (
+  email: string,
+  password: string
+) => {
+  try {
+    const response = await axiosInstance.post(
+      `${API_URL}/sign-in`,
+      { email, password },
+      { withCredentials: true }
+    );
+
+    const { data } = response.data;
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const { path, errorCode, detail, timestamp } = error.response.data;
+      throw new ApiError(path, errorCode, detail, timestamp);
+    }
+    throw new Error(`An unknown error occurred - ${API_URL}/sign-in`);
+  }
+};
+
+/*
+// 로그아웃 API 요청
+export const logout = async () => {
+  const response = await axiosInstance.post(
+    `${API_URL}/logout`,
+    {},
+    { withCredentials: true }
+  );
+  return response.data;
+};
+
+// 회원가입 API 요청
+export const register = async (email: string, password: string) => {
+  const response = await axiosInstance.post(`${API_URL}/register`, {
+    email,
+    password,
+  });
+  return response.data;
+};
+*/

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const axiosInstance = axios.create({
+  baseURL: "http://localhost:3000",
+  withCredentials: true,
+});
+
+export default axiosInstance;

--- a/src/components/templates/AuthLayout/index.tsx
+++ b/src/components/templates/AuthLayout/index.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  children: React.ReactNode;
+}
+
+const AuthLayout = ({ children }: Props) => {
+  return (
+    <div style={{ height: "100vh", display: "flex", justifyContent: "center" }}>
+      {children}
+    </div>
+  );
+};
+
+export default AuthLayout;

--- a/src/components/templates/MainLayout/index.tsx
+++ b/src/components/templates/MainLayout/index.tsx
@@ -24,12 +24,12 @@ const Layout = () => {
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"
-                  stroke-width="1.5"
+                  strokeWidth="1.5"
                   stroke="currentColor"
                 >
                   <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                     d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
                   />
                 </svg>
@@ -41,12 +41,12 @@ const Layout = () => {
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"
-                  stroke-width="1.5"
+                  strokeWidth="1.5"
                   stroke="currentColor"
                 >
                   <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                     d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
                   />
                 </svg>
@@ -58,12 +58,12 @@ const Layout = () => {
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"
-                  stroke-width="1.5"
+                  strokeWidth="1.5"
                   stroke="currentColor"
                 >
                   <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                     d="M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75"
                   />
                 </svg>
@@ -75,12 +75,12 @@ const Layout = () => {
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"
-                  stroke-width="1.5"
+                  strokeWidth="1.5"
                   stroke="currentColor"
                 >
                   <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                     d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
                   />
                 </svg>
@@ -91,12 +91,12 @@ const Layout = () => {
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
-                stroke-width="1.5"
+                strokeWidth="1.5"
                 stroke="currentColor"
               >
                 <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
                   d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15m-3 0-3-3m0 0 3-3m-3 3H15"
                 />
               </svg>
@@ -106,12 +106,12 @@ const Layout = () => {
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
-                stroke-width="1.5"
+                strokeWidth="1.5"
                 stroke="currentColor"
               >
                 <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
                   d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
                 />
               </svg>

--- a/src/components/templates/MainLayout/index.tsx
+++ b/src/components/templates/MainLayout/index.tsx
@@ -1,12 +1,9 @@
-import { Link, Outlet, useNavigate } from "react-router-dom";
+import { Link, Outlet } from "react-router-dom";
 import * as S from "./style";
 
 const Layout = () => {
-  const navigate = useNavigate();
-
   const handleClickLogout = () => {
     // TODO: 로그아웃 로직
-    navigate("/login");
   };
 
   const handleClickMore = () => {

--- a/src/components/templates/MainLayout/index.tsx
+++ b/src/components/templates/MainLayout/index.tsx
@@ -1,7 +1,7 @@
 import { Link, Outlet } from "react-router-dom";
 import * as S from "./style";
 
-const Layout = () => {
+const MainLayout = () => {
   const handleClickLogout = () => {
     // TODO: 로그아웃 로직
   };
@@ -123,4 +123,4 @@ const Layout = () => {
   );
 };
 
-export default Layout;
+export default MainLayout;

--- a/src/components/templates/PrivateRoute/index.tsx
+++ b/src/components/templates/PrivateRoute/index.tsx
@@ -1,0 +1,14 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../../../contexts/auth";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const PrivateRoute = ({ children }: Props) => {
+  const { currentUser } = useAuth();
+
+  return currentUser ? children : <Navigate to="/login" />;
+};
+
+export default PrivateRoute;

--- a/src/contexts/auth.tsx
+++ b/src/contexts/auth.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useState } from "react";
+
+interface Context {
+  currentUser: User | null;
+  signIn: (user: User) => void;
+  signOut: () => void;
+}
+
+const AuthContext = createContext<Context>({
+  currentUser: null,
+  signIn: () => {},
+  signOut: () => {},
+});
+
+export const useAuth = () => useContext(AuthContext);
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface User {
+  id: string;
+  email: string;
+}
+
+export const AuthProvider = ({ children }: Props) => {
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+
+  const signIn = (user: User) => {
+    setCurrentUser(user);
+  };
+
+  const signOut = () => {
+    setCurrentUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ currentUser, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/contexts/auth.tsx
+++ b/src/contexts/auth.tsx
@@ -42,8 +42,7 @@ export const AuthProvider = ({ children }: Props) => {
     const storedUser = localStorage.getItem(STORED_USER_KEY);
 
     if (storedUser) {
-      const user = JSON.parse(storedUser);
-      setCurrentUser(user); // 초기화 시 로컬 스토리지에서 사용자 정보 설정
+      setCurrentUser(JSON.parse(storedUser)); // 초기화 시 로컬 스토리지에서 사용자 정보 설정
     }
   }, []);
 

--- a/src/contexts/auth.tsx
+++ b/src/contexts/auth.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 interface User {
   id: string;
-  email: string;
+  nickname: string;
 }
 
 const STORED_USER_KEY = "currentUser";

--- a/src/contexts/auth.tsx
+++ b/src/contexts/auth.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 
 interface Context {
   currentUser: User | null;
@@ -23,16 +23,29 @@ interface User {
   email: string;
 }
 
+const STORED_USER_KEY = "currentUser";
+
 export const AuthProvider = ({ children }: Props) => {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
 
   const signIn = (user: User) => {
     setCurrentUser(user);
+    localStorage.setItem(STORED_USER_KEY, JSON.stringify(user));
   };
 
   const signOut = () => {
     setCurrentUser(null);
+    localStorage.removeItem(STORED_USER_KEY);
   };
+
+  useEffect(() => {
+    const storedUser = localStorage.getItem(STORED_USER_KEY);
+
+    if (storedUser) {
+      const user = JSON.parse(storedUser);
+      setCurrentUser(user); // 초기화 시 로컬 스토리지에서 사용자 정보 설정
+    }
+  }, []);
 
   return (
     <AuthContext.Provider value={{ currentUser, signIn, signOut }}>

--- a/src/pages/JoinPage/index.tsx
+++ b/src/pages/JoinPage/index.tsx
@@ -1,5 +1,105 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import * as S from "./style";
+import { ApiError } from "../../types/errorTypes";
+import { useAuth } from "../../contexts/auth";
+import { signUpWithEmailAndPassword } from "../../apis/auth";
+
 const JoinPage = () => {
-  return <h1>join</h1>;
+  const navigate = useNavigate();
+  const { currentUser } = useAuth();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [nickname, setNickname] = useState("");
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    if (name === "email") {
+      setEmail(value);
+    } else if (name === "password") {
+      setPassword(value);
+    } else if (name === "nickname") {
+      setNickname(value);
+    }
+  };
+
+  const handleOnSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (isLoading || email === "" || password === "" || nickname === "") {
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+
+      await signUpWithEmailAndPassword(email, password, nickname);
+      navigate("/login");
+    } catch (error) {
+      if (error instanceof ApiError) {
+        if (error.errorCode === "USER_EMAIL_IS_DUPLICATED") {
+          setError(
+            "This email address cannot be used. Please try a different one."
+          );
+        }
+      } else {
+        console.log(error);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (currentUser) {
+      navigate("/");
+    }
+  }, [currentUser, navigate]);
+
+  return (
+    <S.Wrapper>
+      <S.Title>Join to Chagok 💰</S.Title>
+      <S.Form onSubmit={handleOnSubmit}>
+        <S.Input
+          name="email"
+          value={email}
+          placeholder="Email"
+          type="email"
+          onChange={handleOnChange}
+          required
+        />
+        <S.Input
+          name="password"
+          value={password}
+          placeholder="Password"
+          type="password"
+          onChange={handleOnChange}
+          required
+        />
+        <S.Input
+          name="nickname"
+          value={nickname}
+          placeholder="Nickname"
+          onChange={handleOnChange}
+          required
+        />
+        <S.Input
+          type="submit"
+          value={isLoading ? "Loading..." : "Sign up with Email"}
+        />
+      </S.Form>
+      {/* 에러메세지 나중에 모달로 변경 */}
+      <span>{error}</span>
+      <S.Switcher>
+        Already have an account? <Link to="/login">Login &rarr;</Link>
+      </S.Switcher>
+    </S.Wrapper>
+  );
 };
 
 export default JoinPage;

--- a/src/pages/JoinPage/style.ts
+++ b/src/pages/JoinPage/style.ts
@@ -1,0 +1,56 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  width: 420px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Title = styled.h1`
+  font-size: 42px;
+  color: ${({ theme }) => theme.text.primary};
+`;
+
+export const Form = styled.form`
+  margin-top: 50px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  padding: 16px 20px;
+  border-radius: 50px;
+  border: 2px solid ${({ theme }) => theme.button.secondary};
+  outline: none;
+  font-size: 16px;
+
+  &[type="submit"] {
+    background-color: ${({ theme }) => theme.button.primary};
+    color: white;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+
+  &:focus {
+    border: 2px solid ${({ theme }) => theme.button.primary};
+  }
+`;
+
+export const Switcher = styled.span`
+  margin-top: 20px;
+
+  a {
+    color: ${({ theme }) => theme.text.accent};
+  }
+`;

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -45,11 +45,6 @@ const LoginPage = () => {
         if (error.errorCode === "USER_PASSWORD_IS_WRONG") {
           setError("The password you entered is incorrect. Please try again.");
         }
-        if (error.errorCode === "USER_EMAIL_IS_DUPLICATED") {
-          setError(
-            "This email address cannot be used. Please try a different one."
-          );
-        }
       } else {
         console.log(error);
       }

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,5 +1,60 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import * as S from "./style";
+
 const LoginPage = () => {
-  return <h1>login</h1>;
+  const [isLoading, setIsLoading] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    if (name === "email") {
+      setEmail(value);
+    } else if (name === "password") {
+      setPassword(value);
+    }
+  };
+
+  const handleOnSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (isLoading || email === "" || password === "") {
+      return;
+    }
+  };
+
+  return (
+    <S.Wrapper>
+      <S.Title>Log in to Chagok 💰</S.Title>
+      <S.Form onSubmit={handleOnSubmit}>
+        <S.Input
+          name="email"
+          value={email}
+          placeholder="Email"
+          type="email"
+          onChange={handleOnChange}
+          required
+        />
+        <S.Input
+          name="password"
+          value={password}
+          placeholder="Password"
+          type="password"
+          onChange={handleOnChange}
+          required
+        />
+        <S.Input
+          type="submit"
+          value={isLoading ? "Loading..." : "Sign in with Email"}
+        />
+      </S.Form>
+      <S.Switcher>
+        Don't have an account? <Link to="/join">Join &rarr;</Link>
+      </S.Switcher>
+    </S.Wrapper>
+  );
 };
 
 export default LoginPage;

--- a/src/pages/LoginPage/style.ts
+++ b/src/pages/LoginPage/style.ts
@@ -1,0 +1,56 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  width: 420px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Title = styled.h1`
+  font-size: 42px;
+  color: ${({ theme }) => theme.text.primary};
+`;
+
+export const Form = styled.form`
+  margin-top: 50px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  padding: 16px 20px;
+  border-radius: 50px;
+  border: 2px solid ${({ theme }) => theme.button.secondary};
+  outline: none;
+  font-size: 16px;
+
+  &[type="submit"] {
+    background-color: ${({ theme }) => theme.button.primary};
+    color: white;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+
+  &:focus {
+    border: 2px solid ${({ theme }) => theme.button.primary};
+  }
+`;
+
+export const Switcher = styled.span`
+  margin-top: 20px;
+
+  a {
+    color: ${({ theme }) => theme.text.accent};
+  }
+`;

--- a/src/types/errorTypes.ts
+++ b/src/types/errorTypes.ts
@@ -1,0 +1,19 @@
+export class ApiError extends Error {
+  path: string;
+  errorCode: string;
+  detail: number;
+  timestamp: string;
+
+  constructor(
+    path: string,
+    errorCode: string,
+    detail: number,
+    timestamp: string
+  ) {
+    super(`Error ${errorCode}: ${detail}`);
+    this.path = path;
+    this.errorCode = errorCode;
+    this.detail = detail;
+    this.timestamp = timestamp;
+  }
+}


### PR DESCRIPTION
## 🚀 이슈 번호
#3 #6 
<br>

## 💡 변경 이유
- 로그인/회원가입 페이지 구현

<br>

## 🔑 주요 변경사항
- PrivateRoute
  - context로 관리하는 currentUser 여부에 따라 로그인 또는 홈 화면으로 리다이렉트
- AuthContext
  - 로그인 후 사용자 정보를 로컬 스토리지에 저장(새로고침하면 초기화 되기 때문)
  - 이를 전역에서 사용할 수 있도록 AuthProvider를 설정하고 useAuth Hook 추가
  <img width="829" alt="image" src="https://github.com/user-attachments/assets/4be3296c-522e-45df-90f5-f6724c798bbc">

- 로그인/회원가입 페이지 구현
  - 서버 API와 연동 > src/apis 하위에 api 요청 함수 모아둠

<br>

## 📷 테스트 결과
### 로그인

https://github.com/user-attachments/assets/6b10e60d-1887-4912-915d-455e9d2e7d70



### 회원가입

https://github.com/user-attachments/assets/aac7ec65-8c61-4bd6-89ee-d2b428a5461a

