### PR TITLE
내역 생성 / 수정 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import reset from "styled-reset";
 
 import { lightTheme } from "./configs/theme";
 import { AuthProvider } from "./contexts/auth";
+
+import AuthLayout from "./components/templates/AuthLayout";
 import MainLayout from "./components/templates/MainLayout";
 import PrivateRoute from "./components/templates/PrivateRoute";
 
@@ -14,7 +16,7 @@ import ManageBudgetPage from "./pages/ManageBudgetPage";
 import StatsPage from "./pages/StatsPage";
 import LoginPage from "./pages/LoginPage";
 import JoinPage from "./pages/JoinPage";
-import AuthLayout from "./components/templates/AuthLayout";
+import NotFoundPage from "./pages/NotFoundPage";
 
 function App() {
   return (
@@ -73,6 +75,10 @@ const router = createBrowserRouter([
         <JoinPage />
       </AuthLayout>
     ),
+  },
+  {
+    path: "*", // Add the wildcard route here for unmatched paths
+    element: <NotFoundPage />, // This will render the 404 page for any undefined route
   },
 ]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import MainLayout from "./components/templates/MainLayout";
 import PrivateRoute from "./components/templates/PrivateRoute";
 
 import HomePage from "./pages/HomePage";
-import AddTransactionPage from "./pages/AddTransactionPage";
+import ManageTransactionPage from "./pages/ManageTransactionPage";
 import ProfilePage from "./pages/ProfilePage";
 import ManageBudgetPage from "./pages/ManageBudgetPage";
 import StatsPage from "./pages/StatsPage";
@@ -46,7 +46,7 @@ const router = createBrowserRouter([
       },
       {
         path: "/add-transaction",
-        element: <AddTransactionPage />,
+        element: <ManageTransactionPage />,
       },
       {
         path: "/manage-budget",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import StatsPage from "./pages/StatsPage";
 import LoginPage from "./pages/LoginPage";
 import JoinPage from "./pages/JoinPage";
 import NotFoundPage from "./pages/NotFoundPage";
+import ForbiddenPage from "./pages/ForbiddenPage";
 
 function App() {
   return (
@@ -77,8 +78,12 @@ const router = createBrowserRouter([
     ),
   },
   {
-    path: "*", // Add the wildcard route here for unmatched paths
-    element: <NotFoundPage />, // This will render the 404 page for any undefined route
+    path: "/403",
+    element: <ForbiddenPage />,
+  },
+  {
+    path: "*",
+    element: <NotFoundPage />,
   },
 ]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import reset from "styled-reset";
 
 import { lightTheme } from "./configs/theme";
 import { AuthProvider } from "./contexts/auth";
+import { ErrorProvider } from "./contexts/error";
 
 import AuthLayout from "./components/templates/AuthLayout";
 import MainLayout from "./components/templates/MainLayout";
@@ -24,7 +25,9 @@ function App() {
     <AuthProvider>
       <ThemeProvider theme={lightTheme}>
         <GlobalStyles />
-        <RouterProvider router={router} />
+        <ErrorProvider>
+          <RouterProvider router={router} />
+        </ErrorProvider>
       </ThemeProvider>
     </AuthProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ const router = createBrowserRouter([
         element: <ProfilePage />,
       },
       {
-        path: "/add-transaction",
+        path: "/manage-transaction",
         element: <ManageTransactionPage />,
       },
       {

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,4 +1,4 @@
-import axiosInstance from "./axiosInstance";
+import axios from "./axiosInstance";
 
 const API_URL = "/auth";
 
@@ -14,13 +14,13 @@ export const signUpWithEmailAndPassword = async (
   password: string,
   nickname: string
 ) => {
-  const response = (await axiosInstance.post(`${API_URL}/sign-up`, {
+  const response = await axios.post(`${API_URL}/sign-up`, {
     email,
     password,
     nickname,
-  })) as unknown as SignUpResponse;
+  });
 
-  return response;
+  return response as unknown as SignUpResponse;
 };
 
 interface SignInResponse {
@@ -33,17 +33,17 @@ export const signInWithEmailAndPassword = async (
   email: string,
   password: string
 ) => {
-  const response = (await axiosInstance.post(`${API_URL}/sign-in`, {
+  const response = await axios.post(`${API_URL}/sign-in`, {
     email,
     password,
-  })) as unknown as SignInResponse;
+  });
 
-  return response;
+  return response as unknown as SignInResponse;
 };
 
 // 로그아웃
 export const signOut = async () => {
-  await axiosInstance.post(`${API_URL}/sign-out`);
+  await axios.post(`${API_URL}/sign-out`);
 };
 
 // TODO: 회원 탈퇴

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -13,14 +13,23 @@ const onSuccess = (res: AxiosResponse) => {
 };
 
 // 2XX 이외의 응답 처리
-const onFail = (error: unknown) => {
+const onFail = (error: Error) => {
   if (isAxiosError(error) && error.response) {
     const { path, errorCode, detail, timestamp } = error.response.data;
 
     return Promise.reject(new ApiError(path, errorCode, detail, timestamp)); // 커스텀 에러 형식으로 변환
   }
-  return Promise.reject(error);
+  return Promise.reject(
+    new ApiError(
+      "UNKNOWN_ERROR",
+      error.name,
+      error.message,
+      new Date().toISOString()
+    )
+  );
+  // return Promise.reject(error);
 };
+
 axiosInstance.interceptors.response.use(onSuccess, onFail);
 
 export default axiosInstance;

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -16,12 +16,11 @@ const onSuccess = (res: AxiosResponse) => {
 const onFail = (error: unknown) => {
   if (isAxiosError(error) && error.response) {
     const { path, errorCode, detail, timestamp } = error.response.data;
-    // 커스텀 에러 형식으로 변환한다.
-    return Promise.reject(new ApiError(path, errorCode, detail, timestamp));
+
+    return Promise.reject(new ApiError(path, errorCode, detail, timestamp)); // 커스텀 에러 형식으로 변환
   }
   return Promise.reject(error);
 };
-
 axiosInstance.interceptors.response.use(onSuccess, onFail);
 
 export default axiosInstance;

--- a/src/apis/category.ts
+++ b/src/apis/category.ts
@@ -1,0 +1,16 @@
+import axiosInstance from "./axiosInstance";
+
+const API_URL = "/categories";
+
+interface GetCategoriesResponse {
+  id: number;
+  name: string;
+  type: "income" | "expense";
+}
+
+// 회원가입
+export const getCategories = async () => {
+  const response = await axiosInstance.get(`${API_URL}`);
+
+  return response as unknown as GetCategoriesResponse[];
+};

--- a/src/apis/category.ts
+++ b/src/apis/category.ts
@@ -1,4 +1,4 @@
-import axiosInstance from "./axiosInstance";
+import axios from "./axiosInstance";
 
 const API_URL = "/categories";
 
@@ -8,9 +8,11 @@ interface GetCategoriesResponse {
   type: "income" | "expense";
 }
 
-// 회원가입
+/**
+ * 카테고리 목록 조회
+ */
 export const getCategories = async () => {
-  const response = await axiosInstance.get(`${API_URL}`);
+  const response = await axios.get(`${API_URL}`);
 
   return response as unknown as GetCategoriesResponse[];
 };

--- a/src/apis/tx.ts
+++ b/src/apis/tx.ts
@@ -36,3 +36,19 @@ export const getTxs = async (startDate: string, endDate: string) => {
 
   return response as unknown as GetTxsResponse[];
 };
+
+interface GetTxDetailResponse {
+  id: number;
+  categoryId: number;
+  txType: TxType;
+  txMethod: TxMethod;
+  amount: number;
+  date: string;
+  description: string;
+  isExcluded: boolean;
+}
+
+export const getTxDetail = async (txId: number) => {
+  const response = await axiosInstance.get(`${API_URL}/${txId}`);
+  return response as unknown as GetTxDetailResponse;
+};

--- a/src/apis/tx.ts
+++ b/src/apis/tx.ts
@@ -124,5 +124,4 @@ export const getTxDetail = async (txId: number) => {
  */
 export const deleteTx = async (txId: number) => {
   await axios.delete(`${API_URL}/${txId}`);
-  return;
 };

--- a/src/apis/tx.ts
+++ b/src/apis/tx.ts
@@ -2,23 +2,37 @@ import axiosInstance from "./axiosInstance";
 
 const API_URL = "/txs";
 
-// 내역 합계 조회
+type TxType = "income" | "expense";
+type TxMethod = "cash" | "debit card" | "credit card" | "bank transfer";
+
+interface CreateTxResponse {
+  id: number;
+  txType: TxType;
+  txMethod: TxMethod;
+  amount: number;
+  categoryId: number;
+  date: string;
+  description: string;
+  isExcluded: boolean;
+  createdAt: string;
+}
+
+interface UpdateTxResponse {
+  id: number;
+  categoryId: number;
+  txType: TxType;
+  txMethod: TxMethod;
+  amount: number;
+  date: string;
+  description: string;
+  isExcluded: boolean;
+  updatedAt: string;
+}
+
 interface GetTxSumResponse {
   totalIncome: number;
   totalExpense: number;
 }
-
-export const getTxSum = async (startDate: string, endDate: string) => {
-  const response = await axiosInstance.get(`${API_URL}/sum`, {
-    params: { startDate, endDate },
-  });
-
-  return response as unknown as GetTxSumResponse;
-};
-
-// 내역 목록 조회
-type TxType = "income" | "expense";
-type TxMethod = "cash" | "debit card" | "credit card" | "bank transfer";
 
 interface GetTxsResponse {
   id: number;
@@ -28,14 +42,6 @@ interface GetTxsResponse {
   amount: number;
   date: string;
 }
-
-export const getTxs = async (startDate: string, endDate: string) => {
-  const response = await axiosInstance.get(`${API_URL}`, {
-    params: { startDate, endDate },
-  });
-
-  return response as unknown as GetTxsResponse[];
-};
 
 interface GetTxDetailResponse {
   id: number;
@@ -48,6 +54,66 @@ interface GetTxDetailResponse {
   isExcluded: boolean;
 }
 
+/**
+ * 내역 생성
+ */
+export const createTx = async (tx: {
+  txType: TxType;
+  txMethod: TxMethod;
+  amount: number;
+  categoryId: number;
+  date: string;
+  description: string;
+  isExcluded: boolean;
+}) => {
+  const response = await axiosInstance.post(`${API_URL}`, tx);
+
+  return response as unknown as CreateTxResponse;
+};
+
+/*
+ * 내역 수정
+ */
+export const updateTx = async (tx: {
+  id: number;
+  txType: TxType;
+  txMethod: TxMethod;
+  categoryId: number;
+  amount: number;
+  description: string;
+  isExcluded: boolean;
+}) => {
+  const { id, ...body } = tx;
+  const response = await axiosInstance.put(`${API_URL}/${id}`, body);
+
+  return response as unknown as UpdateTxResponse;
+};
+
+/**
+ * 내역 합계 조회
+ */
+export const getTxSum = async (startDate: string, endDate: string) => {
+  const response = await axiosInstance.get(`${API_URL}/sum`, {
+    params: { startDate, endDate },
+  });
+
+  return response as unknown as GetTxSumResponse;
+};
+
+/**
+ * 내역 목록 조회
+ */
+export const getTxs = async (startDate: string, endDate: string) => {
+  const response = await axiosInstance.get(`${API_URL}`, {
+    params: { startDate, endDate },
+  });
+
+  return response as unknown as GetTxsResponse[];
+};
+
+/**
+ * 내역 상세 조회
+ */
 export const getTxDetail = async (txId: number) => {
   const response = await axiosInstance.get(`${API_URL}/${txId}`);
   return response as unknown as GetTxDetailResponse;

--- a/src/apis/tx.ts
+++ b/src/apis/tx.ts
@@ -1,4 +1,4 @@
-import axiosInstance from "./axiosInstance";
+import axios from "./axiosInstance";
 
 const API_URL = "/txs";
 
@@ -66,7 +66,7 @@ export const createTx = async (tx: {
   description: string;
   isExcluded: boolean;
 }) => {
-  const response = await axiosInstance.post(`${API_URL}`, tx);
+  const response = await axios.post(`${API_URL}`, tx);
 
   return response as unknown as CreateTxResponse;
 };
@@ -84,7 +84,7 @@ export const updateTx = async (tx: {
   isExcluded: boolean;
 }) => {
   const { id, ...body } = tx;
-  const response = await axiosInstance.put(`${API_URL}/${id}`, body);
+  const response = await axios.put(`${API_URL}/${id}`, body);
 
   return response as unknown as UpdateTxResponse;
 };
@@ -93,7 +93,7 @@ export const updateTx = async (tx: {
  * 내역 합계 조회
  */
 export const getTxSum = async (startDate: string, endDate: string) => {
-  const response = await axiosInstance.get(`${API_URL}/sum`, {
+  const response = await axios.get(`${API_URL}/sum`, {
     params: { startDate, endDate },
   });
 
@@ -104,7 +104,7 @@ export const getTxSum = async (startDate: string, endDate: string) => {
  * 내역 목록 조회
  */
 export const getTxs = async (startDate: string, endDate: string) => {
-  const response = await axiosInstance.get(`${API_URL}`, {
+  const response = await axios.get(`${API_URL}`, {
     params: { startDate, endDate },
   });
 
@@ -115,6 +115,14 @@ export const getTxs = async (startDate: string, endDate: string) => {
  * 내역 상세 조회
  */
 export const getTxDetail = async (txId: number) => {
-  const response = await axiosInstance.get(`${API_URL}/${txId}`);
+  const response = await axios.get(`${API_URL}/${txId}`);
   return response as unknown as GetTxDetailResponse;
+};
+
+/**
+ * 내역 삭제
+ */
+export const deleteTx = async (txId: number) => {
+  await axios.delete(`${API_URL}/${txId}`);
+  return;
 };

--- a/src/components/atoms/BasicButton/index.tsx
+++ b/src/components/atoms/BasicButton/index.tsx
@@ -1,5 +1,7 @@
 import * as S from "./style";
 
+// NOTE: 감싸서 사용하기
+
 type ButtonSize = "small" | "large";
 type ButtonType = "confirm" | "cancel" | "danger";
 

--- a/src/components/atoms/BasicButton/index.tsx
+++ b/src/components/atoms/BasicButton/index.tsx
@@ -1,0 +1,21 @@
+import * as S from "./style";
+
+type ButtonSize = "small" | "large";
+type ButtonType = "confirm" | "cancel" | "danger";
+
+interface Props {
+  label: string;
+  size: ButtonSize;
+  type: ButtonType;
+  onClick: () => void;
+}
+
+const BasicButton = ({ label, size, type, onClick }: Props) => {
+  return (
+    <S.Button size={size} type={type} onClick={onClick}>
+      {label}
+    </S.Button>
+  );
+};
+
+export default BasicButton;

--- a/src/components/atoms/BasicButton/style.ts
+++ b/src/components/atoms/BasicButton/style.ts
@@ -1,0 +1,45 @@
+import { styled } from "styled-components";
+
+export const Button = styled.button<{
+  size: "small" | "large";
+  type: "confirm" | "cancel" | "danger";
+}>`
+  width: ${({ size }) => (size === "small" ? "80px" : "90px")};
+  height: ${({ size }) => (size === "small" ? "30px" : "40px")};
+  font-size: ${({ size }) => (size === "small" ? "14px" : "18px")};
+  font-weight: 600;
+  display: inline-block;
+  padding: 8px 16px;
+  margin: 4px;
+  border: none;
+  border-radius: 14px;
+  background-color: ${({ theme, type }) => {
+    if (type === "confirm") {
+      return theme.button.primary;
+    }
+    if (type === "cancel") {
+      return theme.button.secondary;
+    }
+    if (type === "danger") {
+      return theme.button.danger;
+    }
+  }};
+  color: ${({ theme, type }) => {
+    if (type === "confirm") {
+      return theme.buttonText.primary;
+    }
+    if (type === "cancel") {
+      return theme.buttonText.secondary;
+    }
+    if (type === "danger") {
+      return theme.buttonText.danger;
+    }
+  }};
+
+  cursor: pointer;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;

--- a/src/components/atoms/BasicButton/style.ts
+++ b/src/components/atoms/BasicButton/style.ts
@@ -4,11 +4,13 @@ export const Button = styled.button<{
   size: "small" | "large";
   type: "confirm" | "cancel" | "danger";
 }>`
-  width: ${({ size }) => (size === "small" ? "80px" : "90px")};
+  display: flex; /* Flexbox 사용 */
+  justify-content: center; /* 수평 중앙 정렬 */
+  align-items: center; /* 수직 중앙 정렬 */
+  width: 90px;
   height: ${({ size }) => (size === "small" ? "30px" : "40px")};
   font-size: ${({ size }) => (size === "small" ? "14px" : "18px")};
   font-weight: 600;
-  display: inline-block;
   padding: 8px 16px;
   margin: 4px;
   border: none;

--- a/src/components/atoms/ChipButton/index.tsx
+++ b/src/components/atoms/ChipButton/index.tsx
@@ -1,0 +1,19 @@
+import * as S from "./style";
+
+// NOTE: 감싸서 사용하기
+
+interface Props {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}
+
+const ChipButton = ({ label, selected, onClick }: Props) => {
+  return (
+    <S.Button selected={selected} onClick={onClick}>
+      {label}
+    </S.Button>
+  );
+};
+
+export default ChipButton;

--- a/src/components/atoms/ChipButton/style.ts
+++ b/src/components/atoms/ChipButton/style.ts
@@ -1,0 +1,25 @@
+import { styled } from "styled-components";
+
+export const Button = styled.button<{ selected: boolean }>`
+  display: inline-block;
+  padding: 8px 16px;
+  margin: 4px;
+  border: none;
+  border-radius: 16px;
+  background-color: ${({ theme, selected }) =>
+    selected ? theme.button.primary : theme.button.tertiary};
+  color: ${({ theme, selected }) =>
+    selected ? theme.buttonText.primary : theme.buttonText.secondary};
+  font-size: 14px;
+  cursor: pointer;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.2s ease-in-out, transform 0.1s ease-in-out;
+
+  &:hover {
+    transform: translateY(-2px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+`;

--- a/src/components/atoms/StyledCheckbox/index.tsx
+++ b/src/components/atoms/StyledCheckbox/index.tsx
@@ -1,0 +1,35 @@
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+
+interface Props {
+  label: string;
+  isChecked: boolean;
+  onChange: (event: React.ChangeEvent) => void;
+}
+
+const StyledCheckbox = ({ label, isChecked, onChange }: Props) => {
+  return (
+    <FormControlLabel
+      control={
+        <Checkbox
+          name="checkbox"
+          checked={isChecked}
+          onChange={onChange}
+          sx={{
+            "&.Mui-checked": {
+              color: "#0D99FF", // 체크된 색상
+            },
+            marginLeft: "16px",
+          }}
+        />
+      }
+      label={label}
+      sx={{
+        color: "#1E1E1E",
+        fontSize: "24px",
+      }}
+    />
+  );
+};
+
+export default StyledCheckbox;

--- a/src/components/organisms/LoadingScreen/style.ts
+++ b/src/components/organisms/LoadingScreen/style.ts
@@ -8,5 +8,5 @@ export const Wrapper = styled.div`
 `;
 
 export const Text = styled.span`
-  font-size: 24px;
+  font-size: 30px;
 `;

--- a/src/components/organisms/LoadingScreen/style.ts
+++ b/src/components/organisms/LoadingScreen/style.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const Wrapper = styled.div`
-  height: 100vh;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/organisms/Modal/index.tsx
+++ b/src/components/organisms/Modal/index.tsx
@@ -20,13 +20,13 @@ const Modal = ({ type, children, buttons }: Props) => {
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
-          stroke-width="1.5"
+          strokeWidth="1.5"
           stroke="currentColor"
           className="size-6"
         >
           <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
+            strokeLinecap="round"
+            strokeLinejoin="round"
             d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
           />
         </svg>
@@ -38,13 +38,13 @@ const Modal = ({ type, children, buttons }: Props) => {
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
-          stroke-width="1.5"
+          strokeWidth="1.5"
           stroke="currentColor"
           className="size-6"
         >
           <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
+            strokeLinecap="round"
+            strokeLinejoin="round"
             d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"
           />
         </svg>
@@ -56,13 +56,13 @@ const Modal = ({ type, children, buttons }: Props) => {
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
-          stroke-width="1.5"
+          strokeWidth="1.5"
           stroke="currentColor"
           className="size-6"
         >
           <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
+            strokeLinecap="round"
+            strokeLinejoin="round"
             d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
           />
         </svg>

--- a/src/components/organisms/Modal/index.tsx
+++ b/src/components/organisms/Modal/index.tsx
@@ -1,0 +1,111 @@
+import { ReactNode } from "react";
+import * as S from "./style";
+import BasicButton from "../../atoms/BasicButton";
+
+interface Props {
+  type: "error" | "warn" | "success";
+  buttons: Array<{
+    label: string;
+    location: "left" | "right" | "center"; // center: 버튼이 하나일 경우
+    onClick: () => void;
+  }>;
+  children: ReactNode;
+}
+
+const Modal = ({ type, children, buttons }: Props) => {
+  const renderIcon = () => {
+    if (type === "error") {
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          className="size-6"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+          />
+        </svg>
+      );
+    }
+    if (type === "warn") {
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          className="size-6"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"
+          />
+        </svg>
+      );
+    }
+    if (type === "success") {
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          className="size-6"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+          />
+        </svg>
+      );
+    }
+  };
+
+  const renderButtons = () => {
+    return buttons.map((button, index) => {
+      let buttonType: "cancel" | "confirm" | "danger" = "cancel";
+
+      if (button.location === "left") {
+        buttonType = "cancel";
+      } else {
+        if (type === "error" || type === "warn") {
+          buttonType = "danger";
+        }
+        if (type === "success") {
+          buttonType = "confirm";
+        }
+      }
+
+      return (
+        <BasicButton
+          key={index}
+          label={button.label}
+          size="small"
+          type={buttonType}
+          onClick={button.onClick}
+        />
+      );
+    });
+  };
+
+  return (
+    <S.ModalOverlay>
+      <S.ModalContainer>
+        <S.HeaderIcon>{renderIcon()}</S.HeaderIcon>
+        <S.Content>{children}</S.Content>
+        <S.Footer>{renderButtons()}</S.Footer>
+      </S.ModalContainer>
+    </S.ModalOverlay>
+  );
+};
+
+export default Modal;

--- a/src/components/organisms/Modal/style.ts
+++ b/src/components/organisms/Modal/style.ts
@@ -1,0 +1,64 @@
+import styled, { keyframes } from "styled-components";
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(-20px); /* 모달이 위에서 내려오는 효과 */
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  opacity: 0; /* 초기값 */
+  animation: ${fadeIn} 0.3s ease forwards; /* 서서히 나타나는 애니메이션 */
+`;
+
+export const ModalContainer = styled.div`
+  width: 400px;
+  max-width: 90%;
+  background-color: ${({ theme }) => theme.background.white};
+  border-radius: 15px;
+  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
+  padding: 40px 20px;
+  z-index: 1001;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const HeaderIcon = styled.div`
+  width: 16%;
+  height: 16%;
+  color: ${({ theme }) => theme.text.primary};
+`;
+
+export const Content = styled.div`
+  padding: 30px 20px;
+  font-size: 1rem;
+  color: ${({ theme }) => theme.text.primary};
+  text-align: center;
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  justify-content: center;
+  padding-top: 10px;
+
+  & > button {
+    margin: 0 30px;
+  }
+`;

--- a/src/components/templates/AuthLayout/index.tsx
+++ b/src/components/templates/AuthLayout/index.tsx
@@ -1,8 +1,21 @@
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../../contexts/auth";
+import { useEffect } from "react";
+
 interface Props {
   children: React.ReactNode;
 }
 
 const AuthLayout = ({ children }: Props) => {
+  const navigate = useNavigate();
+  const { currentUser } = useAuth();
+
+  useEffect(() => {
+    if (currentUser) {
+      navigate("/");
+    }
+  }, [currentUser, navigate]);
+
   return (
     <div
       style={{

--- a/src/components/templates/AuthLayout/index.tsx
+++ b/src/components/templates/AuthLayout/index.tsx
@@ -4,7 +4,13 @@ interface Props {
 
 const AuthLayout = ({ children }: Props) => {
   return (
-    <div style={{ height: "100vh", display: "flex", justifyContent: "center" }}>
+    <div
+      style={{
+        height: "100vh",
+        display: "flex",
+        justifyContent: "center",
+      }}
+    >
       {children}
     </div>
   );

--- a/src/components/templates/MainLayout/index.tsx
+++ b/src/components/templates/MainLayout/index.tsx
@@ -1,28 +1,27 @@
+import { useState } from "react";
 import { Link, Outlet, useNavigate } from "react-router-dom";
 
 import * as S from "./style";
+import Modal from "../../organisms/Modal";
 import { signOut } from "../../../apis/auth";
 import { useAuth } from "../../../contexts/auth";
+import { useError } from "../../../contexts/error";
 import { ApiError } from "../../../types/errorTypes";
 
 const MainLayout = () => {
   const navigate = useNavigate();
   const { deauthenticate } = useAuth();
+  const { handleApiError } = useError();
+  const [isOpen, setIsOpen] = useState(false);
 
-  const handleClickLogout = async () => {
-    const ok = confirm("정말 로그아웃 하시겠습니까?"); // TODO: 모달로 변경
-    if (ok) {
-      try {
-        await signOut();
-        deauthenticate();
-        navigate("/login", { replace: true });
-      } catch (error) {
-        if (error instanceof ApiError) {
-          if (error.errorCode === "AUTH_INVALID_TOKEN") {
-            deauthenticate();
-            navigate("/login", { replace: true });
-          }
-        }
+  const handleLogout = async () => {
+    try {
+      await signOut();
+      deauthenticate();
+      navigate("/login", { replace: true });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        handleApiError(error, navigate);
       }
     }
   };
@@ -104,7 +103,7 @@ const MainLayout = () => {
                 </svg>
               </S.MenuItem>
             </Link>
-            <S.MenuItem className="logout" onClick={handleClickLogout}>
+            <S.MenuItem className="logout" onClick={() => setIsOpen(true)}>
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -140,6 +139,25 @@ const MainLayout = () => {
           <Outlet />
         </S.RightWrapper>
       </S.Container>
+      {isOpen && (
+        <Modal
+          type="success"
+          buttons={[
+            {
+              label: "Cancel",
+              location: "left",
+              onClick: () => setIsOpen(false),
+            },
+            {
+              label: "Log out",
+              location: "right",
+              onClick: handleLogout,
+            },
+          ]}
+        >
+          <p style={{ lineHeight: "1.5" }}>Are you sure you want to log out?</p>
+        </Modal>
+      )}
     </>
   );
 };

--- a/src/components/templates/PrivateRoute/index.tsx
+++ b/src/components/templates/PrivateRoute/index.tsx
@@ -1,5 +1,7 @@
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../../../contexts/auth";
+import { useEffect, useState } from "react";
+import LoadingScreen from "../../organisms/LoadingScreen";
 
 interface Props {
   children: React.ReactNode;
@@ -7,8 +9,18 @@ interface Props {
 
 const PrivateRoute = ({ children }: Props) => {
   const { currentUser } = useAuth();
+  const [isLoading, setIsLoading] = useState(true);
 
-  return currentUser ? children : <Navigate to="/login" />;
+  useEffect(() => {
+    if (currentUser) {
+      setIsLoading(false);
+    }
+  }, [currentUser]);
+
+  if (isLoading) {
+    return <LoadingScreen />;
+  }
+  return currentUser ? children : <Navigate to="/login" replace />;
 };
 
 export default PrivateRoute;

--- a/src/components/templates/PrivateRoute/index.tsx
+++ b/src/components/templates/PrivateRoute/index.tsx
@@ -12,10 +12,8 @@ const PrivateRoute = ({ children }: Props) => {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (currentUser) {
-      setIsLoading(false);
-    }
-  }, [currentUser]);
+    setIsLoading(false);
+  }, []);
 
   if (isLoading) {
     return <LoadingScreen />;

--- a/src/configs/theme.ts
+++ b/src/configs/theme.ts
@@ -15,6 +15,7 @@ export const lightTheme = {
   button: {
     primary: DARK_BLUE,
     secondary: LIGHT_GRAY,
+    tertiary: WHITE,
     danger: RED,
   },
   text: {
@@ -30,27 +31,3 @@ export const lightTheme = {
     danger: WHITE,
   },
 };
-
-export interface LightTheme {
-  background: {
-    white: string;
-    light_blue: string;
-  };
-  button: {
-    primary: string;
-    secondary: string;
-    danger: string;
-  };
-  text: {
-    primary: string;
-    secondary: string;
-    tertiary: string;
-    accent: string;
-    danger: string;
-  };
-  buttonText: {
-    primary: string;
-    secondary: string;
-    danger: string;
-  };
-}

--- a/src/contexts/error.tsx
+++ b/src/contexts/error.tsx
@@ -1,0 +1,70 @@
+import { createContext, useState, useContext } from "react";
+import Modal from "../components/organisms/Modal";
+import { ApiError } from "../types/errorTypes";
+
+interface Context {
+  errorMessage: string | null;
+  handleApiError: (error: ApiError) => void;
+}
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const ErrorContext = createContext<Context>({
+  errorMessage: null,
+  handleApiError: () => {},
+});
+
+export const useError = () => useContext(ErrorContext);
+
+export const ErrorProvider = ({ children }: Props) => {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleApiError = (error: ApiError) => {
+    const { errorCode } = error;
+
+    switch (errorCode) {
+      // 401
+      case "USER_EMAIL_DO_NOT_EXIST":
+        setErrorMessage(
+          "The email address you entered doesn't match any account."
+        );
+        break;
+      case "USER_PASSWORD_IS_WRONG":
+        setErrorMessage(
+          "The password you entered is incorrect. Please try again."
+        );
+        break;
+      case "CATEGORY_NOT_FOUND":
+        setErrorMessage("Invalid category.");
+        break;
+      case "TX_AMOUNT_OUT_OF_RANGE":
+        setErrorMessage("Please enter the amount.");
+        break;
+      default:
+        setErrorMessage(error.detail);
+        break;
+    }
+  };
+
+  return (
+    <ErrorContext.Provider value={{ errorMessage, handleApiError }}>
+      {children}
+      {errorMessage && (
+        <Modal
+          type="error"
+          buttons={[
+            {
+              label: "Close",
+              location: "center",
+              onClick: () => setErrorMessage(null),
+            },
+          ]}
+        >
+          <p style={{ lineHeight: "1.5" }}>{errorMessage}</p>
+        </Modal>
+      )}
+    </ErrorContext.Provider>
+  );
+};

--- a/src/contexts/error.tsx
+++ b/src/contexts/error.tsx
@@ -1,6 +1,7 @@
 import { createContext, useState, useContext } from "react";
 import { NavigateFunction } from "react-router-dom";
 
+import { useAuth } from "./auth";
 import Modal from "../components/organisms/Modal";
 import { ApiError } from "../types/errorTypes";
 
@@ -20,11 +21,9 @@ export const useError = () => useContext(ErrorContext);
 
 export const ErrorProvider = ({ children }: Props) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { deauthenticate } = useAuth();
 
-  const handleApiError = (
-    error: ApiError,
-    navigateFn?: (to: string) => void
-  ) => {
+  const handleApiError = (error: ApiError, navigateFn?: NavigateFunction) => {
     const { errorCode } = error;
 
     switch (errorCode) {
@@ -33,6 +32,10 @@ export const ErrorProvider = ({ children }: Props) => {
         setErrorMessage("Please enter the amount.");
         break;
       // 401
+      case "AUTH_INVALID_TOKEN":
+        deauthenticate();
+        navigateFn?.("/login", { replace: true });
+        break;
       case "USER_EMAIL_DO_NOT_EXIST":
         setErrorMessage(
           "The email address you entered doesn't match any account."

--- a/src/contexts/error.tsx
+++ b/src/contexts/error.tsx
@@ -40,7 +40,7 @@ export const ErrorProvider = ({ children }: Props) => {
         break;
       case "USER_PASSWORD_IS_WRONG":
         setErrorMessage(
-          "The password you entered is incorrect. Please try again."
+          "The password you entered is incorrect.\nPlease try again."
         );
         break;
       // 404

--- a/src/contexts/error.tsx
+++ b/src/contexts/error.tsx
@@ -51,6 +51,12 @@ export const ErrorProvider = ({ children }: Props) => {
       case "TX_FORBIDDEN":
         navigateFn?.("/403");
         break;
+      // 409
+      case "USER_EMAIL_IS_DUPLICATED":
+        setErrorMessage(
+          "This email address cannot be used.\nPlease try a different one."
+        );
+        break;
       default:
         setErrorMessage(error.detail);
         break;

--- a/src/pages/AddTransactionPage/index.tsx
+++ b/src/pages/AddTransactionPage/index.tsx
@@ -1,5 +1,0 @@
-const AddEntryPage = () => {
-  return <h1>add transaction</h1>;
-};
-
-export default AddEntryPage;

--- a/src/pages/ForbiddenPage/index.tsx
+++ b/src/pages/ForbiddenPage/index.tsx
@@ -1,23 +1,24 @@
 import { useNavigate } from "react-router-dom";
+
 import * as S from "./style";
 
-const NotFoundPage = () => {
+const ForbiddenPage = () => {
   const navigate = useNavigate();
 
   const handleGoHome = () => {
-    navigate("/", { replace: true });
+    navigate("/");
   };
 
   return (
     <S.Container>
-      <S.Title>404</S.Title>
-      <S.Subtitle>Page Not Found</S.Subtitle>
+      <S.Title>403</S.Title>
+      <S.Subtitle>Forbidden</S.Subtitle>
       <S.Description>
-        Sorry, the page you are looking for doesn't exist.
+        Sorry, you don’t have permission to access this resource.
       </S.Description>
       <S.Button onClick={handleGoHome}>Go Home</S.Button>
     </S.Container>
   );
 };
 
-export default NotFoundPage;
+export default ForbiddenPage;

--- a/src/pages/ForbiddenPage/style.ts
+++ b/src/pages/ForbiddenPage/style.ts
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: ${({ theme }) => theme.background.white};
+  text-align: center;
+`;
+
+export const Title = styled.h1`
+  font-size: 100px;
+  color: ${({ theme }) => theme.text.primary};
+`;
+
+export const Subtitle = styled.h2`
+  font-size: 36px;
+  color: ${({ theme }) => theme.text.secondary};
+  margin-bottom: 16px;
+`;
+
+export const Description = styled.p`
+  font-size: 18px;
+  color: ${({ theme }) => theme.text.secondary};
+  margin-bottom: 40px;
+`;
+
+export const Button = styled.button`
+  background-color: ${({ theme }) => theme.button.primary};
+  color: white;
+  padding: 12px 24px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 16px;
+
+  &:hover {
+    opacity: 0.9;
+  }
+`;

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -72,11 +72,12 @@ const HomePage = () => {
   const handleClickAdd = () => {
     navigate("/manage-transaction", {
       state: { selectedDate: selectedDate.toISOString() },
+      replace: true,
     });
   };
 
   const handleClickListItem = (txId: number) => {
-    navigate("/manage-transaction", { state: { txId } });
+    navigate("/manage-transaction", { state: { txId }, replace: true });
   };
 
   useEffect(() => {

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -70,7 +70,9 @@ const HomePage = () => {
   };
 
   const handleClickAdd = () => {
-    navigate("/manage-transaction");
+    navigate("/manage-transaction", {
+      state: { selectedDate: selectedDate.toISOString() },
+    });
   };
 
   const handleClickListItem = (txId: number) => {

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -6,9 +6,10 @@ import * as S from "./style";
 import { getSelectedDate, saveSelectedDate } from "./util";
 
 import { getTxs, getTxSum } from "../../apis/tx";
+import { useAuth } from "../../contexts/auth";
+import { useError } from "../../contexts/error";
 import Calendar from "../../components/organisms/Calendar";
 import Header from "../../components/organisms/Header";
-import { useAuth } from "../../contexts/auth";
 import { capitalize } from "../../utils/string";
 import { ApiError } from "../../types/errorTypes";
 
@@ -32,7 +33,8 @@ interface Tx {
 const HomePage = () => {
   const initialDate = getSelectedDate();
   const navigate = useNavigate();
-  const { currentUser, deauthenticate } = useAuth();
+  const { currentUser } = useAuth();
+  const { handleApiError } = useError();
 
   const [selectedDate, setSelectedDate] = useState(
     dayjs(initialDate ?? undefined)
@@ -56,10 +58,7 @@ const HomePage = () => {
       setTxs(txs);
     } catch (error) {
       if (error instanceof ApiError) {
-        if (error.errorCode === "AUTH_INVALID_TOKEN") {
-          deauthenticate();
-          navigate("/login", { replace: true });
-        }
+        handleApiError(error, navigate);
       }
     }
   }, []);

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -64,13 +64,17 @@ const HomePage = () => {
     }
   }, []);
 
-  const handleOnClickAdd = () => {
-    navigate("/manage-transaction");
-  };
-
   const handleChangeDate = async (date: Dayjs) => {
     fetchData(date);
     saveSelectedDate(date.toISOString());
+  };
+
+  const handleClickAdd = () => {
+    navigate("/manage-transaction");
+  };
+
+  const handleClickListItem = (txId: number) => {
+    navigate("/manage-transaction", { state: { txId } });
   };
 
   useEffect(() => {
@@ -94,16 +98,17 @@ const HomePage = () => {
       </S.LeftWrapper>
       <S.RightWrapper>
         <S.ButtonContainer>
-          <S.AddButton onClick={handleOnClickAdd}>
-            Add a transaction
-          </S.AddButton>
+          <S.AddButton onClick={handleClickAdd}>Add a transaction</S.AddButton>
         </S.ButtonContainer>
         <S.ListItemContainer>
           {txs.length === 0 ? (
             <S.Empty>Try to add a new transaction!</S.Empty>
           ) : (
             txs.map((tx) => (
-              <S.ListItem key={tx.id}>
+              <S.ListItem
+                key={tx.id}
+                onClick={() => handleClickListItem(tx.id)}
+              >
                 <S.Category>{capitalize(tx.categoryName)}</S.Category>
                 <S.PaymentMethod>{capitalize(tx.txMethod)}</S.PaymentMethod>
                 <S.Amount type={tx.txType}>

--- a/src/pages/HomePage/style.ts
+++ b/src/pages/HomePage/style.ts
@@ -37,6 +37,7 @@ export const ButtonContainer = styled.div`
   height: 40px;
   background-color: ${({ theme }) => theme.background.light_blue};
   margin-bottom: 44px;
+  padding-right: 20px;
 `;
 
 export const AddButton = styled.button`
@@ -48,7 +49,7 @@ export const AddButton = styled.button`
   background-color: ${({ theme }) => theme.button.primary};
   border-radius: 50px;
   border: none;
-  margin-bottom: 44px;
+  margin: 0px 0px 44px 4px;
   cursor: pointer;
 
   &:hover {
@@ -58,6 +59,7 @@ export const AddButton = styled.button`
 
 export const ListItemContainer = styled.div`
   overflow-y: auto;
+  padding-right: 20px;
 `;
 
 export const ListItem = styled.div`
@@ -68,9 +70,14 @@ export const ListItem = styled.div`
   border-radius: 20px;
   background-color: ${({ theme }) => theme.background.white};
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
-  margin-bottom: 20px;
   padding: 0 20px;
+  margin: 0px 0px 20px 4px;
   font-size: 14px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.button.secondary};
+  }
 `;
 
 export const Category = styled.div`

--- a/src/pages/JoinPage/index.tsx
+++ b/src/pages/JoinPage/index.tsx
@@ -1,15 +1,13 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import * as S from "./style";
 import { signUpWithEmailAndPassword } from "../../apis/auth";
-import { useAuth } from "../../contexts/auth";
 import { useError } from "../../contexts/error";
 import { ApiError } from "../../types/errorTypes";
 
 const JoinPage = () => {
   const navigate = useNavigate();
-  const { currentUser } = useAuth();
   const { handleApiError } = useError();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -53,12 +51,6 @@ const JoinPage = () => {
     }
   };
 
-  useEffect(() => {
-    if (currentUser) {
-      navigate("/");
-    }
-  }, [currentUser, navigate]);
-
   return (
     <S.Wrapper>
       <S.Title>Join to Chagok 💰</S.Title>
@@ -92,8 +84,6 @@ const JoinPage = () => {
           value={isLoading ? "Loading..." : "Sign up with Email"}
         />
       </S.Form>
-      {/* 에러메세지 나중에 모달로 변경 */}
-      {/* <span>{error}</span> */}
       <S.Switcher>
         Already have an account? <Link to="/login">Login &rarr;</Link>
       </S.Switcher>

--- a/src/pages/JoinPage/index.tsx
+++ b/src/pages/JoinPage/index.tsx
@@ -2,16 +2,17 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import * as S from "./style";
-import { ApiError } from "../../types/errorTypes";
-import { useAuth } from "../../contexts/auth";
 import { signUpWithEmailAndPassword } from "../../apis/auth";
+import { useAuth } from "../../contexts/auth";
+import { useError } from "../../contexts/error";
+import { ApiError } from "../../types/errorTypes";
 
 const JoinPage = () => {
   const navigate = useNavigate();
   const { currentUser } = useAuth();
+  const { handleApiError } = useError();
 
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [nickname, setNickname] = useState("");
@@ -42,11 +43,7 @@ const JoinPage = () => {
       navigate("/login");
     } catch (error) {
       if (error instanceof ApiError) {
-        if (error.errorCode === "USER_EMAIL_IS_DUPLICATED") {
-          setError(
-            "This email address cannot be used. Please try a different one."
-          );
-        }
+        handleApiError(error);
       }
     } finally {
       setIsLoading(false);
@@ -96,7 +93,7 @@ const JoinPage = () => {
         />
       </S.Form>
       {/* 에러메세지 나중에 모달로 변경 */}
-      <span>{error}</span>
+      {/* <span>{error}</span> */}
       <S.Switcher>
         Already have an account? <Link to="/login">Login &rarr;</Link>
       </S.Switcher>

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import * as S from "./style";
@@ -9,7 +9,7 @@ import { useError } from "../../contexts/error";
 
 const LoginPage = () => {
   const navigate = useNavigate();
-  const { authenticate, currentUser } = useAuth();
+  const { authenticate } = useAuth();
   const { handleApiError } = useError();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -46,12 +46,6 @@ const LoginPage = () => {
       setIsLoading(false);
     }
   };
-
-  useEffect(() => {
-    if (currentUser) {
-      navigate("/");
-    }
-  }, [currentUser, navigate]);
 
   return (
     <S.Wrapper>

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -5,15 +5,16 @@ import * as S from "./style";
 import { signInWithEmailAndPassword } from "../../apis/auth";
 import { ApiError } from "../../types/errorTypes";
 import { useAuth } from "../../contexts/auth";
+import { useError } from "../../contexts/error";
 
 const LoginPage = () => {
   const navigate = useNavigate();
   const { authenticate, currentUser } = useAuth();
+  const { handleApiError } = useError();
 
   const [isLoading, setIsLoading] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
 
   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -39,14 +40,7 @@ const LoginPage = () => {
       navigate("/", { replace: true });
     } catch (error) {
       if (error instanceof ApiError) {
-        if (error.errorCode === "USER_EMAIL_DO_NOT_EXIST") {
-          setError("The email address you entered doesn't match any account.");
-        }
-        if (error.errorCode === "USER_PASSWORD_IS_WRONG") {
-          setError("The password you entered is incorrect. Please try again.");
-        }
-      } else {
-        console.log(error);
+        handleApiError(error);
       }
     } finally {
       setIsLoading(false);
@@ -84,8 +78,6 @@ const LoginPage = () => {
           value={isLoading ? "Loading..." : "Sign in with Email"}
         />
       </S.Form>
-      {/* 에러메세지 나중에 모달로 변경 */}
-      <span>{error}</span>
       <S.Switcher>
         Don't have an account? <Link to="/join">Join &rarr;</Link>
       </S.Switcher>

--- a/src/pages/ManageTransactionPage/index.tsx
+++ b/src/pages/ManageTransactionPage/index.tsx
@@ -1,5 +1,279 @@
+import { useLocation } from "react-router-dom";
+import Header from "../../components/organisms/Header";
+import { styled } from "styled-components";
+import ChipButton from "../../components/atoms/ChipButton";
+import { useState } from "react";
+import { capitalize } from "../../utils/string";
+import StyledCheckbox from "../../components/atoms/StyledCheckbox";
+import BasicButton from "../../components/atoms/BasicButton";
+
+// TODO: input 컴포넌트 분리
+// TODO: API 연동
+
+type TxType = "income" | "expense";
+type TxMethod = "cash" | "debit card" | "credit card" | "bank transfer";
+
+interface Category {
+  id: number;
+  name: string;
+  type: TxType;
+}
+
 const ManageTransactionPage = () => {
-  return <h1>add transaction</h1>;
+  const location = useLocation();
+  const { txId, date } = location.state || {};
+
+  const [tx, setTx] = useState({
+    txType: "income",
+    txMethod: "cash",
+    categoryId: 1,
+    amount: 0,
+    description: "",
+    date,
+    isExcluded: false,
+  });
+  const [cagegories, setCategories] = useState<Category[]>([
+    { id: 1, name: "salary", type: "income" },
+    { id: 2, name: "business", type: "income" },
+    { id: 3, name: "investment", type: "income" },
+    { id: 4, name: "other income", type: "income" },
+    { id: 5, name: "food", type: "expense" },
+    { id: 6, name: "housing", type: "expense" },
+    { id: 7, name: "transportation", type: "expense" },
+    { id: 8, name: "healthcare", type: "expense" },
+    { id: 9, name: "communication", type: "expense" },
+    { id: 10, name: "education", type: "expense" },
+    { id: 11, name: "entertainment", type: "expense" },
+    { id: 12, name: "shopping", type: "expense" },
+    { id: 13, name: "household", type: "expense" },
+    { id: 14, name: "insurance", type: "expense" },
+    { id: 15, name: "tax", type: "expense" },
+    { id: 16, name: "pet", type: "expense" },
+    { id: 17, name: "subscription", type: "expense" },
+    { id: 18, name: "donation", type: "expense" },
+    { id: 19, name: "other expense", type: "expense" },
+  ]);
+
+  const handleSelectTxType = (txType: TxType) => {
+    setTx({ ...tx, txType });
+  };
+
+  const handleSelectTxMethod = (txMethod: TxMethod) => {
+    setTx({ ...tx, txMethod });
+  };
+
+  const handleSelectCategory = (categoryId: number) => {
+    setTx({ ...tx, categoryId });
+  };
+
+  const handleChangeAmount = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    // 1000 단위로 끊은 문자열을 number로 변환
+    setTx({ ...tx, amount: Number(value.replace(/[,]/g, "")) });
+  };
+
+  const handleChangeDescription = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { value } = event.target;
+    setTx({ ...tx, description: value });
+  };
+
+  const handleChangeCheckbox = () => {
+    setTx({ ...tx, isExcluded: !tx.isExcluded });
+  };
+
+  const handleClickDelete = () => {
+    console.log("delete");
+  };
+
+  const renderCategories = () => {
+    return cagegories.map((category) => {
+      if (category.type === tx.txType) {
+        return (
+          <ChipButton
+            key={category.id}
+            label={capitalize(category.name)}
+            selected={tx.categoryId === category.id}
+            onClick={() => handleSelectCategory(category.id)}
+          />
+        );
+      }
+    });
+  };
+
+  return (
+    <Wrapper>
+      <LeftWrapper>
+        <Header
+          title={txId ? "Edit a transaction" : "Add a transaction"}
+          description="Enter your income or expenses."
+        />
+        <ResultContainer></ResultContainer>
+      </LeftWrapper>
+      <RightWrapper>
+        <SelectorWrapper>
+          <SubTitle>Type</SubTitle>
+          <ChipGroup>
+            <ChipButton
+              label="Income"
+              selected={tx.txType === "income"}
+              onClick={() => handleSelectTxType("income")}
+            />
+            <ChipButton
+              label="Expense"
+              selected={tx.txType === "expense"}
+              onClick={() => handleSelectTxType("expense")}
+            />
+          </ChipGroup>
+        </SelectorWrapper>
+        <SelectorWrapper>
+          <SubTitle>Transaction Method</SubTitle>
+          <ChipGroup>
+            <ChipButton
+              label="Cash"
+              selected={tx.txMethod === "cash"}
+              onClick={() => handleSelectTxMethod("cash")}
+            />
+            <ChipButton
+              label="Dedit Card"
+              selected={tx.txMethod === "debit card"}
+              onClick={() => handleSelectTxMethod("debit card")}
+            />
+            <ChipButton
+              label="Credit Card"
+              selected={tx.txMethod === "credit card"}
+              onClick={() => handleSelectTxMethod("credit card")}
+            />
+            <ChipButton
+              label="Bank Transfer"
+              selected={tx.txMethod === "bank transfer"}
+              onClick={() => handleSelectTxMethod("bank transfer")}
+            />
+          </ChipGroup>
+        </SelectorWrapper>
+        <SelectorWrapper>
+          <SubTitle>Category</SubTitle>
+          <ChipGroup>{renderCategories()}</ChipGroup>
+        </SelectorWrapper>
+        <SelectorWrapper>
+          <SubTitle>Amount</SubTitle>
+          <Input
+            name="amount"
+            value={tx.amount.toLocaleString()}
+            placeholder="Please enter numbers only."
+            onChange={handleChangeAmount}
+          />
+        </SelectorWrapper>
+        <SelectorWrapper>
+          <SubTitle>Description</SubTitle>
+          <Input
+            name="description"
+            placeholder="This field is optional."
+            onChange={handleChangeDescription}
+          />
+        </SelectorWrapper>
+        <SelectorWrapper>
+          <StyledCheckbox
+            label="Exclude from transaction sum"
+            isChecked={tx.isExcluded}
+            onChange={handleChangeCheckbox}
+          />
+        </SelectorWrapper>
+        <DeleteButtonWrapper>
+          <BasicButton
+            label="Delete"
+            type="danger"
+            size="large"
+            onClick={handleClickDelete}
+          />
+        </DeleteButtonWrapper>
+      </RightWrapper>
+    </Wrapper>
+  );
 };
 
 export default ManageTransactionPage;
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  padding-left: 30px;
+  display: flex;
+  gap: 30px;
+`;
+
+export const LeftWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  gap: 20px;
+`;
+
+export const ResultContainer = styled.div`
+  height: 100%;
+  min-height: fit-content;
+  background-color: ${({ theme }) => theme.background.white};
+  border-radius: 20px;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  padding: 30px;
+`;
+
+export const RightWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  padding-right: 20px;
+`;
+
+export const SelectorWrapper = styled.div`
+  margin-bottom: 30px;
+`;
+
+export const SubTitle = styled.h1`
+  font-size: 20px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.text.accent};
+  margin-bottom: 10px;
+  margin: 0px 0px 10px 4px;
+`;
+
+export const ChipGroup = styled.div`
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  padding: 16px 20px;
+  border-radius: 50px;
+  border: 1px solid transparent;
+  color: ${({ theme }) => theme.text.primary};
+  outline: none;
+  font-size: 16px;
+
+  &:focus {
+    border: 1px solid ${({ theme }) => theme.button.primary};
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.text.tertiary}; /* 원하는 색상으로 변경 */
+    opacity: 0.7; /* 투명도 조절 (선택적) */
+  }
+
+  /* type="number"일 때 스피너 숨기기 */
+  &[type="number"]&::-webkit-outer-spin-button,
+  &[type="number"]&::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+`;
+
+export const DeleteButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 20px;
+`;

--- a/src/pages/ManageTransactionPage/index.tsx
+++ b/src/pages/ManageTransactionPage/index.tsx
@@ -14,6 +14,8 @@ import LoadingScreen from "../../components/organisms/LoadingScreen";
 import { capitalize } from "../../utils/string";
 import { localize } from "../../utils/date";
 
+const DEFAULT_INCOME_CATEGORY_ID = 1;
+const DEFAULT_EXPENSE_CATEGORY_ID = 5;
 const MAT_AMOUNT = 20000000000;
 const MAX_DESCRIPTION_LENGTH = 100;
 
@@ -41,9 +43,6 @@ interface HomeState {
   txId?: number;
   selectedDate?: string;
 }
-
-const DEFAULT_INCOME_CATEGORY_ID = 1;
-const DEFAULT_EXPENSE_CATEGORY_ID = 5;
 
 const ManageTransactionPage = () => {
   const location = useLocation();
@@ -147,17 +146,17 @@ const ManageTransactionPage = () => {
     });
   };
 
-  const fetchData = async () => {
-    const categories = await getCategories();
-    setCategories(categories);
-
-    if (isEditPage) {
-      const txDetail = await getTxDetail(txId);
-      setTx(txDetail);
-    }
-  };
-
   useEffect(() => {
+    const fetchData = async () => {
+      const categories = await getCategories();
+      setCategories(categories);
+
+      if (isEditPage) {
+        const txDetail = await getTxDetail(txId);
+        setTx(txDetail);
+      }
+    };
+
     const timeoutId = setTimeout(() => {
       setIsLoading(false);
     }, 1000);
@@ -167,7 +166,7 @@ const ManageTransactionPage = () => {
     return () => clearTimeout(timeoutId);
   }, []);
 
-  if (isLoading) {
+  if (isEditPage && isLoading) {
     return <LoadingScreen />;
   }
 

--- a/src/pages/ManageTransactionPage/index.tsx
+++ b/src/pages/ManageTransactionPage/index.tsx
@@ -189,17 +189,17 @@ const ManageTransactionPage = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const categories = await getCategories();
-      setCategories(categories);
+      try {
+        const categories = await getCategories();
+        setCategories(categories);
 
-      if (isEditPage) {
-        try {
+        if (isEditPage) {
           const txDetail = await getTxDetail(txId);
           setTx(txDetail);
-        } catch (error) {
-          if (error instanceof ApiError) {
-            handleApiError(error, navigate);
-          }
+        }
+      } catch (error) {
+        if (error instanceof ApiError) {
+          handleApiError(error, navigate);
         }
       }
     };

--- a/src/pages/ManageTransactionPage/index.tsx
+++ b/src/pages/ManageTransactionPage/index.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import * as S from "./style";
 import { getCategories } from "../../apis/category";
-import { getTxDetail } from "../../apis/tx";
+import { createTx, getTxDetail, updateTx } from "../../apis/tx";
 
 import BasicButton from "../../components/atoms/BasicButton";
 import ChipButton from "../../components/atoms/ChipButton";
@@ -13,6 +13,7 @@ import LoadingScreen from "../../components/organisms/LoadingScreen";
 
 import { capitalize } from "../../utils/string";
 import { localize } from "../../utils/date";
+import { ApiError } from "../../types/errorTypes";
 
 const DEFAULT_INCOME_CATEGORY_ID = 1;
 const DEFAULT_EXPENSE_CATEGORY_ID = 5;
@@ -45,6 +46,7 @@ interface HomeState {
 }
 
 const ManageTransactionPage = () => {
+  const navigate = useNavigate();
   const location = useLocation();
   const { txId, selectedDate } = (location.state as HomeState) || {};
 
@@ -116,6 +118,33 @@ const ManageTransactionPage = () => {
 
   const handleChangeCheckbox = () => {
     setTx({ ...tx, isExcluded: !tx.isExcluded });
+  };
+
+  const handleClickCancel = () => {
+    // TODO: 모달로 변경
+  };
+
+  const handleClickAddOrUpdate = async () => {
+    try {
+      if (isAddPage) {
+        await createTx(tx);
+      }
+      if (isEditPage) {
+        await updateTx({ id: txId, ...tx });
+      }
+    } catch (error) {
+      if (error instanceof ApiError) {
+        // TODO: 모달로 변경
+        if (error.errorCode === "CATEGORY_NOT_FOUND") {
+          console.log(error.detail);
+        }
+        if (error.errorCode === "TX_FORBIDDEN") {
+          console.log(error.detail);
+        }
+      }
+    } finally {
+      navigate("/", { replace: true });
+    }
   };
 
   const handleClickDelete = () => {
@@ -202,7 +231,7 @@ const ManageTransactionPage = () => {
               label={isAddPage ? "Add" : "Update"}
               size="large"
               type="confirm"
-              onClick={() => console.log("등록")}
+              onClick={handleClickAddOrUpdate}
             />
           </S.ButtonGroup>
         </S.TransactionContainer>

--- a/src/pages/ManageTransactionPage/index.tsx
+++ b/src/pages/ManageTransactionPage/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { styled } from "styled-components";
 
+import * as S from "./style";
 import { getCategories } from "../../apis/category";
 import { getTxDetail } from "../../apis/tx";
 
@@ -171,27 +171,27 @@ const ManageTransactionPage = () => {
   }
 
   return (
-    <Wrapper>
-      <LeftWrapper>
+    <S.Wrapper>
+      <S.LeftWrapper>
         <Header
           title={isEditPage ? "Edit a transaction" : "Add a transaction"}
           description="Enter your income or expenses."
         />
-        <TransactionContainer>
-          <Date>{renderDate()}</Date>
-          <Type>{capitalize(tx.txType)}</Type>
-          <Amount>₩{tx.amount.toLocaleString()}</Amount>
-          <Category>
+        <S.TransactionContainer>
+          <S.Date>{renderDate()}</S.Date>
+          <S.Type>{capitalize(tx.txType)}</S.Type>
+          <S.Amount>₩{tx.amount.toLocaleString()}</S.Amount>
+          <S.Category>
             {capitalize(
               categories.find(({ id }) => id === tx.categoryId)?.name ?? ""
             )}
-          </Category>
-          <Description>
+          </S.Category>
+          <S.Description>
             {`${capitalize(tx.txMethod)}${
               tx.description ? ` - ${tx.description}` : ""
             }`}
-          </Description>
-          <ButtonGroup>
+          </S.Description>
+          <S.ButtonGroup>
             <BasicButton
               label="Cancel"
               size="large"
@@ -204,13 +204,13 @@ const ManageTransactionPage = () => {
               type="confirm"
               onClick={() => console.log("등록")}
             />
-          </ButtonGroup>
-        </TransactionContainer>
-      </LeftWrapper>
-      <RightWrapper>
-        <SelectorWrapper>
-          <SubTitle>Type</SubTitle>
-          <ChipGroup>
+          </S.ButtonGroup>
+        </S.TransactionContainer>
+      </S.LeftWrapper>
+      <S.RightWrapper>
+        <S.SelectorWrapper>
+          <S.SubTitle>Type</S.SubTitle>
+          <S.ChipGroup>
             <ChipButton
               label="Income"
               selected={tx.txType === "income"}
@@ -221,11 +221,11 @@ const ManageTransactionPage = () => {
               selected={tx.txType === "expense"}
               onClick={() => handleSelectTxType("expense")}
             />
-          </ChipGroup>
-        </SelectorWrapper>
-        <SelectorWrapper>
-          <SubTitle>Transaction Method</SubTitle>
-          <ChipGroup>
+          </S.ChipGroup>
+        </S.SelectorWrapper>
+        <S.SelectorWrapper>
+          <S.SubTitle>Transaction Method</S.SubTitle>
+          <S.ChipGroup>
             <ChipButton
               label="Cash"
               selected={tx.txMethod === "cash"}
@@ -246,173 +246,49 @@ const ManageTransactionPage = () => {
               selected={tx.txMethod === "bank transfer"}
               onClick={() => handleSelectTxMethod("bank transfer")}
             />
-          </ChipGroup>
-        </SelectorWrapper>
-        <SelectorWrapper>
-          <SubTitle>Category</SubTitle>
-          <ChipGroup>{renderCategoryChips()}</ChipGroup>
-        </SelectorWrapper>
-        <SelectorWrapper>
-          <SubTitle>Amount</SubTitle>
-          <Input
+          </S.ChipGroup>
+        </S.SelectorWrapper>
+        <S.SelectorWrapper>
+          <S.SubTitle>Category</S.SubTitle>
+          <S.ChipGroup>{renderCategoryChips()}</S.ChipGroup>
+        </S.SelectorWrapper>
+        <S.SelectorWrapper>
+          <S.SubTitle>Amount</S.SubTitle>
+          <S.Input
             name="amount"
             value={tx.amount.toLocaleString()}
             onChange={handleChangeAmount}
           />
-        </SelectorWrapper>
-        <SelectorWrapper>
-          <SubTitle>Description</SubTitle>
-          <Input
+        </S.SelectorWrapper>
+        <S.SelectorWrapper>
+          <S.SubTitle>Description</S.SubTitle>
+          <S.Input
             name="description"
             value={tx.description}
             placeholder="This field is optional."
             onChange={handleChangeDescription}
           />
-        </SelectorWrapper>
-        <SelectorWrapper>
+        </S.SelectorWrapper>
+        <S.SelectorWrapper>
           <StyledCheckbox
             label="Exclude from transaction sum"
             isChecked={tx.isExcluded}
             onChange={handleChangeCheckbox}
           />
-        </SelectorWrapper>
+        </S.SelectorWrapper>
         {isEditPage && (
-          <DeleteButtonWrapper>
+          <S.DeleteButtonWrapper>
             <BasicButton
               label="Delete"
               type="danger"
               size="large"
               onClick={handleClickDelete}
             />
-          </DeleteButtonWrapper>
+          </S.DeleteButtonWrapper>
         )}
-      </RightWrapper>
-    </Wrapper>
+      </S.RightWrapper>
+    </S.Wrapper>
   );
 };
 
 export default ManageTransactionPage;
-
-export const Wrapper = styled.div`
-  width: 100%;
-  height: 100%;
-  padding-left: 30px;
-  display: flex;
-  gap: 30px;
-`;
-
-export const LeftWrapper = styled.div`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-evenly;
-  gap: 20px;
-`;
-
-export const TransactionContainer = styled.div`
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  background-color: ${({ theme }) => theme.background.white};
-  border-radius: 20px;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
-  padding: 30px;
-  text-align: center;
-  overflow-y: auto;
-`;
-
-export const Date = styled.h1`
-  color: ${({ theme }) => theme.text.secondary};
-  margin-top: 20px;
-  margin-bottom: 80px;
-`;
-
-export const Type = styled.h1`
-  color: ${({ theme }) => theme.text.accent};
-  margin-bottom: 20px;
-  font-size: 20px;
-  font-weight: 500;
-`;
-
-export const Amount = styled.h1`
-  color: ${({ theme }) => theme.text.primary};
-  font-size: 50px;
-  margin-bottom: 50px;
-`;
-
-export const Category = styled.h1`
-  color: ${({ theme }) => theme.text.secondary};
-  font-size: 30px;
-  margin-bottom: 20px;
-`;
-
-export const Description = styled.h1`
-  color: ${({ theme }) => theme.text.secondary};
-  font-size: 18px;
-  margin-bottom: 100px;
-  max-width: 100%;
-`;
-
-export const ButtonGroup = styled.div`
-  display: flex;
-  justify-content: center;
-  gap: 20px;
-`;
-
-export const RightWrapper = styled.div`
-  width: 100%;
-  height: 100%;
-  overflow-y: auto;
-  padding-right: 20px;
-`;
-
-export const SelectorWrapper = styled.div`
-  margin-bottom: 30px;
-`;
-
-export const SubTitle = styled.h1`
-  font-size: 20px;
-  font-weight: 700;
-  color: ${({ theme }) => theme.text.accent};
-  margin-bottom: 10px;
-  margin: 0px 0px 10px 4px;
-`;
-
-export const ChipGroup = styled.div`
-  display: flex;
-  gap: 4px;
-  flex-wrap: wrap;
-`;
-
-export const Input = styled.input`
-  width: 100%;
-  padding: 16px 20px;
-  border-radius: 50px;
-  border: 1px solid transparent;
-  color: ${({ theme }) => theme.text.primary};
-  outline: none;
-  font-size: 16px;
-
-  &:focus {
-    border: 1px solid ${({ theme }) => theme.button.primary};
-  }
-
-  &::placeholder {
-    color: ${({ theme }) => theme.text.tertiary}; /* 원하는 색상으로 변경 */
-    opacity: 0.7; /* 투명도 조절 (선택적) */
-  }
-
-  /* type="number"일 때 스피너 숨기기 */
-  &[type="number"]&::-webkit-outer-spin-button,
-  &[type="number"]&::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-`;
-
-export const DeleteButtonWrapper = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 20px;
-`;

--- a/src/pages/ManageTransactionPage/index.tsx
+++ b/src/pages/ManageTransactionPage/index.tsx
@@ -10,6 +10,7 @@ import ChipButton from "../../components/atoms/ChipButton";
 import StyledCheckbox from "../../components/atoms/StyledCheckbox";
 import Header from "../../components/organisms/Header";
 import LoadingScreen from "../../components/organisms/LoadingScreen";
+import Modal from "../../components/organisms/Modal";
 
 import { ApiError } from "../../types/errorTypes";
 import { capitalize } from "../../utils/string";
@@ -54,6 +55,7 @@ const ManageTransactionPage = () => {
   const isAddPage = !!selectedDate;
 
   const [isLoading, setIsLoading] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const [categories, setCategories] = useState<Category[]>([]);
   const [tx, setTx] = useState<Tx>({
     id: txId,
@@ -120,11 +122,11 @@ const ManageTransactionPage = () => {
     setTx({ ...tx, isExcluded: !tx.isExcluded });
   };
 
-  const handleClickCancel = () => {
-    // TODO: 모달로 변경
+  const handleCancel = () => {
+    navigate("/");
   };
 
-  const handleClickAddOrUpdate = async () => {
+  const handleAddOrUpdate = async () => {
     try {
       if (isAddPage) {
         await createTx(tx);
@@ -148,10 +150,13 @@ const ManageTransactionPage = () => {
   };
 
   const handleClickDelete = async () => {
+    setIsOpen(true);
+  };
+
+  const handleClickModalRightBtn = async () => {
     if (!isEditPage) {
       return;
     }
-    // TODO: 모달 연결(yes or no)
 
     try {
       await deleteTx(txId);
@@ -224,123 +229,147 @@ const ManageTransactionPage = () => {
   }
 
   return (
-    <S.Wrapper>
-      <S.LeftWrapper>
-        <Header
-          title={isEditPage ? "Edit a transaction" : "Add a transaction"}
-          description="Enter your income or expenses."
-        />
-        <S.TransactionContainer>
-          <S.Date>{renderDate()}</S.Date>
-          <S.Type>{capitalize(tx.txType)}</S.Type>
-          <S.Amount>₩{tx.amount.toLocaleString()}</S.Amount>
-          <S.Category>
-            {capitalize(
-              categories.find(({ id }) => id === tx.categoryId)?.name ?? ""
-            )}
-          </S.Category>
-          <S.Description>
-            {`${capitalize(tx.txMethod)}${
-              tx.description ? ` - ${tx.description}` : ""
-            }`}
-          </S.Description>
-          <S.ButtonGroup>
-            <BasicButton
-              label="Cancel"
-              size="large"
-              type="cancel"
-              onClick={() => console.log("취소")}
-            />
-            <BasicButton
-              label={isAddPage ? "Add" : "Update"}
-              size="large"
-              type="confirm"
-              onClick={handleClickAddOrUpdate}
-            />
-          </S.ButtonGroup>
-        </S.TransactionContainer>
-      </S.LeftWrapper>
-      <S.RightWrapper>
-        <S.SelectorWrapper>
-          <S.SubTitle>Type</S.SubTitle>
-          <S.ChipGroup>
-            <ChipButton
-              label="Income"
-              selected={tx.txType === "income"}
-              onClick={() => handleSelectTxType("income")}
-            />
-            <ChipButton
-              label="Expense"
-              selected={tx.txType === "expense"}
-              onClick={() => handleSelectTxType("expense")}
-            />
-          </S.ChipGroup>
-        </S.SelectorWrapper>
-        <S.SelectorWrapper>
-          <S.SubTitle>Transaction Method</S.SubTitle>
-          <S.ChipGroup>
-            <ChipButton
-              label="Cash"
-              selected={tx.txMethod === "cash"}
-              onClick={() => handleSelectTxMethod("cash")}
-            />
-            <ChipButton
-              label="Debit Card"
-              selected={tx.txMethod === "debit card"}
-              onClick={() => handleSelectTxMethod("debit card")}
-            />
-            <ChipButton
-              label="Credit Card"
-              selected={tx.txMethod === "credit card"}
-              onClick={() => handleSelectTxMethod("credit card")}
-            />
-            <ChipButton
-              label="Bank Transfer"
-              selected={tx.txMethod === "bank transfer"}
-              onClick={() => handleSelectTxMethod("bank transfer")}
-            />
-          </S.ChipGroup>
-        </S.SelectorWrapper>
-        <S.SelectorWrapper>
-          <S.SubTitle>Category</S.SubTitle>
-          <S.ChipGroup>{renderCategoryChips()}</S.ChipGroup>
-        </S.SelectorWrapper>
-        <S.SelectorWrapper>
-          <S.SubTitle>Amount</S.SubTitle>
-          <S.Input
-            name="amount"
-            value={tx.amount.toLocaleString()}
-            onChange={handleChangeAmount}
+    <>
+      <S.Wrapper>
+        <S.LeftWrapper>
+          <Header
+            title={isEditPage ? "Edit a transaction" : "Add a transaction"}
+            description="Enter your income or expenses."
           />
-        </S.SelectorWrapper>
-        <S.SelectorWrapper>
-          <S.SubTitle>Description</S.SubTitle>
-          <S.Input
-            name="description"
-            value={tx.description}
-            placeholder="This field is optional."
-            onChange={handleChangeDescription}
-          />
-        </S.SelectorWrapper>
-        <S.SelectorWrapper>
-          <StyledCheckbox
-            label="Exclude from transaction sum"
-            isChecked={tx.isExcluded}
-            onChange={handleChangeCheckbox}
-          />
-        </S.SelectorWrapper>
-        {isEditPage && (
-          <S.DeleteButtonWrapper>
-            <BasicButton
-              label="Delete"
-              type="danger"
-              size="large"
-              onClick={handleClickDelete}
+          <S.TransactionContainer>
+            <S.Date>{renderDate()}</S.Date>
+            <S.Type>{capitalize(tx.txType)}</S.Type>
+            <S.Amount>₩{tx.amount.toLocaleString()}</S.Amount>
+            <S.Category>
+              {capitalize(
+                categories.find(({ id }) => id === tx.categoryId)?.name ?? ""
+              )}
+            </S.Category>
+            <S.Description>
+              {`${capitalize(tx.txMethod)}${
+                tx.description ? ` - ${tx.description}` : ""
+              }`}
+            </S.Description>
+            <S.ButtonGroup>
+              <BasicButton
+                label="Cancel"
+                size="large"
+                type="cancel"
+                onClick={handleCancel}
+              />
+              <BasicButton
+                label={isAddPage ? "Add" : "Update"}
+                size="large"
+                type="confirm"
+                onClick={handleAddOrUpdate}
+              />
+            </S.ButtonGroup>
+          </S.TransactionContainer>
+        </S.LeftWrapper>
+        <S.RightWrapper>
+          <S.SelectorWrapper>
+            <S.SubTitle>Type</S.SubTitle>
+            <S.ChipGroup>
+              <ChipButton
+                label="Income"
+                selected={tx.txType === "income"}
+                onClick={() => handleSelectTxType("income")}
+              />
+              <ChipButton
+                label="Expense"
+                selected={tx.txType === "expense"}
+                onClick={() => handleSelectTxType("expense")}
+              />
+            </S.ChipGroup>
+          </S.SelectorWrapper>
+          <S.SelectorWrapper>
+            <S.SubTitle>Transaction Method</S.SubTitle>
+            <S.ChipGroup>
+              <ChipButton
+                label="Cash"
+                selected={tx.txMethod === "cash"}
+                onClick={() => handleSelectTxMethod("cash")}
+              />
+              <ChipButton
+                label="Debit Card"
+                selected={tx.txMethod === "debit card"}
+                onClick={() => handleSelectTxMethod("debit card")}
+              />
+              <ChipButton
+                label="Credit Card"
+                selected={tx.txMethod === "credit card"}
+                onClick={() => handleSelectTxMethod("credit card")}
+              />
+              <ChipButton
+                label="Bank Transfer"
+                selected={tx.txMethod === "bank transfer"}
+                onClick={() => handleSelectTxMethod("bank transfer")}
+              />
+            </S.ChipGroup>
+          </S.SelectorWrapper>
+          <S.SelectorWrapper>
+            <S.SubTitle>Category</S.SubTitle>
+            <S.ChipGroup>{renderCategoryChips()}</S.ChipGroup>
+          </S.SelectorWrapper>
+          <S.SelectorWrapper>
+            <S.SubTitle>Amount</S.SubTitle>
+            <S.Input
+              name="amount"
+              value={tx.amount.toLocaleString()}
+              onChange={handleChangeAmount}
             />
-          </S.DeleteButtonWrapper>
-        )}
-      </S.RightWrapper>
-    </S.Wrapper>
+          </S.SelectorWrapper>
+          <S.SelectorWrapper>
+            <S.SubTitle>Description</S.SubTitle>
+            <S.Input
+              name="description"
+              value={tx.description}
+              placeholder="This field is optional."
+              onChange={handleChangeDescription}
+            />
+          </S.SelectorWrapper>
+          <S.SelectorWrapper>
+            <StyledCheckbox
+              label="Exclude from transaction sum"
+              isChecked={tx.isExcluded}
+              onChange={handleChangeCheckbox}
+            />
+          </S.SelectorWrapper>
+          {isEditPage && (
+            <S.DeleteButtonWrapper>
+              <BasicButton
+                label="Delete"
+                type="danger"
+                size="large"
+                onClick={handleClickDelete}
+              />
+            </S.DeleteButtonWrapper>
+          )}
+        </S.RightWrapper>
+      </S.Wrapper>
+      {isOpen && (
+        <Modal
+          type="warn"
+          buttons={[
+            {
+              label: "Cancel",
+              location: "left",
+              onClick: () => setIsOpen(false),
+            },
+            {
+              label: "Delete",
+              location: "right",
+              onClick: handleClickModalRightBtn,
+            },
+          ]}
+        >
+          <p style={{ lineHeight: "1.5" }}>
+            Are you sure you want to delete this?{<br />}This action cannot be
+            undone.
+          </p>
+        </Modal>
+      )}
+    </>
   );
 };
 

--- a/src/pages/ManageTransactionPage/index.tsx
+++ b/src/pages/ManageTransactionPage/index.tsx
@@ -1,0 +1,5 @@
+const ManageTransactionPage = () => {
+  return <h1>add transaction</h1>;
+};
+
+export default ManageTransactionPage;

--- a/src/pages/ManageTransactionPage/style.ts
+++ b/src/pages/ManageTransactionPage/style.ts
@@ -1,0 +1,125 @@
+import { styled } from "styled-components";
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  padding-left: 30px;
+  display: flex;
+  gap: 30px;
+`;
+
+export const LeftWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  gap: 20px;
+`;
+
+export const TransactionContainer = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background-color: ${({ theme }) => theme.background.white};
+  border-radius: 20px;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  padding: 30px;
+  text-align: center;
+  overflow-y: auto;
+`;
+
+export const Date = styled.h1`
+  color: ${({ theme }) => theme.text.secondary};
+  margin-top: 20px;
+  margin-bottom: 80px;
+`;
+
+export const Type = styled.h1`
+  color: ${({ theme }) => theme.text.accent};
+  margin-bottom: 20px;
+  font-size: 20px;
+  font-weight: 500;
+`;
+
+export const Amount = styled.h1`
+  color: ${({ theme }) => theme.text.primary};
+  font-size: 50px;
+  margin-bottom: 50px;
+`;
+
+export const Category = styled.h1`
+  color: ${({ theme }) => theme.text.secondary};
+  font-size: 30px;
+  margin-bottom: 20px;
+`;
+
+export const Description = styled.h1`
+  color: ${({ theme }) => theme.text.secondary};
+  font-size: 18px;
+  margin-bottom: 100px;
+  max-width: 100%;
+`;
+
+export const ButtonGroup = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+`;
+
+export const RightWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  padding-right: 20px;
+`;
+
+export const SelectorWrapper = styled.div`
+  margin-bottom: 30px;
+`;
+
+export const SubTitle = styled.h1`
+  font-size: 20px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.text.accent};
+  margin-bottom: 10px;
+  margin: 0px 0px 10px 4px;
+`;
+
+export const ChipGroup = styled.div`
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  padding: 16px 20px;
+  border-radius: 50px;
+  border: 1px solid transparent;
+  color: ${({ theme }) => theme.text.primary};
+  outline: none;
+  font-size: 16px;
+
+  &:focus {
+    border: 1px solid ${({ theme }) => theme.button.primary};
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.text.tertiary}; /* 원하는 색상으로 변경 */
+    opacity: 0.7; /* 투명도 조절 (선택적) */
+  }
+
+  /* type="number"일 때 스피너 숨기기 */
+  &[type="number"]&::-webkit-outer-spin-button,
+  &[type="number"]&::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+`;
+
+export const DeleteButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 20px;
+`;

--- a/src/pages/NotFoundPage/index.tsx
+++ b/src/pages/NotFoundPage/index.tsx
@@ -1,0 +1,23 @@
+import { useNavigate } from "react-router-dom";
+import * as S from "./style";
+
+const NotFoundPage = () => {
+  const navigate = useNavigate();
+
+  const handleGoHome = () => {
+    navigate("/");
+  };
+
+  return (
+    <S.Container>
+      <S.Title>404</S.Title>
+      <S.Subtitle>Page Not Found</S.Subtitle>
+      <S.Description>
+        Sorry, the page you are looking for doesn't exist.
+      </S.Description>
+      <S.Button onClick={handleGoHome}>Go Home</S.Button>
+    </S.Container>
+  );
+};
+
+export default NotFoundPage;

--- a/src/pages/NotFoundPage/style.ts
+++ b/src/pages/NotFoundPage/style.ts
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: ${({ theme }) => theme.background.white};
+  text-align: center;
+`;
+
+export const Title = styled.h1`
+  font-size: 100px;
+  color: ${({ theme }) => theme.text.primary};
+`;
+
+export const Subtitle = styled.h2`
+  font-size: 36px;
+  color: ${({ theme }) => theme.text.secondary};
+  margin-bottom: 16px;
+`;
+
+export const Description = styled.p`
+  font-size: 18px;
+  color: ${({ theme }) => theme.text.secondary};
+  margin-bottom: 40px;
+`;
+
+export const Button = styled.button`
+  background-color: ${({ theme }) => theme.button.primary};
+  color: white;
+  padding: 12px 24px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 16px;
+
+  &:hover {
+    opacity: 0.9;
+  }
+`;

--- a/src/types/errorTypes.ts
+++ b/src/types/errorTypes.ts
@@ -1,13 +1,13 @@
 export class ApiError extends Error {
   path: string;
   errorCode: string;
-  detail: number;
+  detail: string;
   timestamp: string;
 
   constructor(
     path: string,
     errorCode: string,
-    detail: number,
+    detail: string,
     timestamp: string
   ) {
     super(`Error ${errorCode}: ${detail}`);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,5 @@
+import dayjs from "dayjs";
+
+export const localize = (date: string) => {
+  return dayjs(date).format("ddd, MMM D, YYYY");
+};


### PR DESCRIPTION
## 🚀 이슈 번호
#4 #9
<br>

## 💡 변경 이유
- 내역 생성 / 수정 페이지 구현
<br>

## 🔑 주요 변경사항
- 403, 404 페이지 구현
  - ForbiddenPage: API 요청 후 403 에러를 받을 때 보여줄 페이지
  - NotFoundPage: 정해놓은 경로 이외의 경로로 접근시 보여줄 페이지
- ErrorProvider 구현
  - ApiError 핸들링을 전역적으로 하기 위한 Context Provider
  - handleError 함수를 전달하여 errorCode대로 처리함. 
    - ApiError가 발생하면 type이 "error"인 모달을 띄움.
    - ApiError를 발생시키기 위해 axios interceptor에서 모든 에러를 ApiError로 변환하여 반환하도록 수정.
  - handleError의 두 번째 매개변수로 navigate 함수를 전달함.
    - Router 안에서만 useNavigate()를 사용할 수 있기 때문에 페이지에서 전달하는 것으로 결정하였음.
- 컴포넌트 구현
  - BasicButton
  - ChipButton
  - Checkbox
  - Modal
- 내역 생성 / 수정 페이지 구현
  - API 연동
    - 카테고리 조회
    - 내역 목록 조회
    - 내역 상세 조회
    - 내역 생성
    - 내역 수정
    - 내역 삭제
    - 로그아웃
  - Modal 연결

<br>

## 📷 테스트 결과

https://github.com/user-attachments/assets/66e860ff-d9ca-4999-b0c7-469a23cb6bee

https://github.com/user-attachments/assets/6e3a8aa4-69c1-4fcf-bee9-a753effda7e2

https://github.com/user-attachments/assets/8f638e12-a99e-451c-8997-a83340d322eb

https://github.com/user-attachments/assets/91a42a5c-4bc9-4eb6-9719-61e3abeb1300


