### PR TITLE
사용자 프로필 페이지

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -47,6 +47,6 @@ export const signOut = async () => {
 };
 
 // 회원 탈퇴
-export const deleteUser = async () => {
-  await axios.delete(`${API_URL}/account`);
+export const deleteUser = async (email: string) => {
+  await axios.post(`${API_URL}/delete-account`, { email });
 };

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -46,4 +46,7 @@ export const signOut = async () => {
   await axios.post(`${API_URL}/sign-out`);
 };
 
-// TODO: 회원 탈퇴
+// 회원 탈퇴
+export const deleteUser = async () => {
+  await axios.delete(`${API_URL}/account`);
+};

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,0 +1,38 @@
+import axios from "./axiosInstance";
+
+const API_URL = "/users";
+
+interface GetUserResponse {
+  id: string;
+  email: string;
+  nickname: string;
+}
+
+/**
+ * 사용자 조회
+ */
+export const getUser = async () => {
+  const response = await axios.get(`${API_URL}`);
+
+  return response as unknown as GetUserResponse;
+};
+
+/**
+ * 사용자 프로필 수정
+ */
+export const updateUserProfile = async ({ nickname }: { nickname: string }) => {
+  await axios.patch(`${API_URL}/profile`, { nickname });
+};
+
+/**
+ * 사용자 비밀번호 수정
+ */
+export const updateUserPassword = async (
+  oldPassword: string,
+  newPassword: string
+) => {
+  await axios.patch(`${API_URL}/password`, {
+    oldPassword,
+    newPassword,
+  });
+};

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -8,6 +8,12 @@ interface GetUserResponse {
   nickname: string;
 }
 
+interface UpdateUserProfileResponse {
+  id: string;
+  email: string;
+  nickname: string;
+}
+
 /**
  * 사용자 조회
  */
@@ -21,7 +27,9 @@ export const getUser = async () => {
  * 사용자 프로필 수정
  */
 export const updateUserProfile = async ({ nickname }: { nickname: string }) => {
-  await axios.patch(`${API_URL}/profile`, { nickname });
+  const response = await axios.patch(`${API_URL}/profile`, { nickname });
+
+  return response as unknown as UpdateUserProfileResponse;
 };
 
 /**

--- a/src/components/atoms/BasicButton/index.tsx
+++ b/src/components/atoms/BasicButton/index.tsx
@@ -3,18 +3,24 @@ import * as S from "./style";
 // NOTE: 감싸서 사용하기
 
 type ButtonSize = "small" | "large";
-type ButtonType = "confirm" | "cancel" | "danger";
+type ButtonType = "default" | "confirm" | "cancel" | "danger";
 
 interface Props {
   label: string;
   size: ButtonSize;
-  type: ButtonType;
+  type?: ButtonType /* default: "default" */;
+  disabled?: boolean /* default: false */;
   onClick: () => void;
 }
 
-const BasicButton = ({ label, size, type, onClick }: Props) => {
+const BasicButton = ({ label, size, type, disabled, onClick }: Props) => {
   return (
-    <S.Button size={size} type={type} onClick={onClick}>
+    <S.Button
+      size={size}
+      type={type ?? "default"}
+      onClick={onClick}
+      disabled={disabled ?? false}
+    >
       {label}
     </S.Button>
   );

--- a/src/components/atoms/BasicButton/style.ts
+++ b/src/components/atoms/BasicButton/style.ts
@@ -2,7 +2,7 @@ import { styled } from "styled-components";
 
 export const Button = styled.button<{
   size: "small" | "large";
-  type: "confirm" | "cancel" | "danger";
+  type: "default" | "confirm" | "cancel" | "danger";
 }>`
   display: flex; /* Flexbox 사용 */
   justify-content: center; /* 수평 중앙 정렬 */
@@ -25,6 +25,9 @@ export const Button = styled.button<{
     if (type === "danger") {
       return theme.button.danger;
     }
+    if (type === "default") {
+      return theme.button.tertiary;
+    }
   }};
   color: ${({ theme, type }) => {
     if (type === "confirm") {
@@ -43,5 +46,9 @@ export const Button = styled.button<{
 
   &:hover {
     opacity: 0.8;
+  }
+
+  &:disabled {
+    opacity: 0.6;
   }
 `;

--- a/src/components/atoms/BasicButton/style.ts
+++ b/src/components/atoms/BasicButton/style.ts
@@ -7,7 +7,7 @@ export const Button = styled.button<{
   display: flex; /* Flexbox 사용 */
   justify-content: center; /* 수평 중앙 정렬 */
   align-items: center; /* 수직 중앙 정렬 */
-  width: 90px;
+  min-width: 90px;
   height: ${({ size }) => (size === "small" ? "30px" : "40px")};
   font-size: ${({ size }) => (size === "small" ? "14px" : "18px")};
   font-weight: 600;

--- a/src/contexts/error.tsx
+++ b/src/contexts/error.tsx
@@ -27,7 +27,8 @@ export const ErrorProvider = ({ children }: Props) => {
     const { errorCode } = error;
 
     switch (errorCode) {
-      // 400
+      // ===== 400 =====
+      // budget
       case "BUDGET_AMOUNT_OUT_OF_RANGE":
         setErrorMessage(
           "Please enter a category amount less than or equal to 2 billion."
@@ -43,10 +44,13 @@ export const ErrorProvider = ({ children }: Props) => {
           "You have reached the limit for budget creation in the selected year and month."
         );
         break;
+      // tx
       case "TX_AMOUNT_OUT_OF_RANGE":
         setErrorMessage("Please enter the amount.");
         break;
-      // 401
+      // user
+
+      // ===== 401 =====
       case "AUTH_INVALID_TOKEN":
         deauthenticate();
         navigateFn?.("/login", { replace: true });
@@ -61,18 +65,21 @@ export const ErrorProvider = ({ children }: Props) => {
           "The password you entered is incorrect.\nPlease try again."
         );
         break;
-      // 404
-      case "CATEGORY_NOT_FOUND":
-        setErrorMessage("Invalid category.");
-        break;
-      // 403
+
+      // ===== 403 =====
       case "BUDGET_FORBIDDEN":
         navigateFn?.("/403");
         break;
       case "TX_FORBIDDEN":
         navigateFn?.("/403");
         break;
-      // 409
+
+      // ===== 404 =====
+      case "CATEGORY_NOT_FOUND":
+        setErrorMessage("Invalid category.");
+        break;
+
+      // ===== 409 =====
       case "USER_EMAIL_IS_DUPLICATED":
         setErrorMessage(
           "This email address cannot be used.\nPlease try a different one."

--- a/src/pages/HomePage/util.ts
+++ b/src/pages/HomePage/util.ts
@@ -8,6 +8,6 @@ export const saveSelectedDate = (date: string) => {
   sessionStorage.setItem(INITIAL_DATE_KEY, date);
 };
 
-export const removeSelectedDate = (date: string) => {
+export const removeSelectedDate = () => {
   sessionStorage.removeItem(INITIAL_DATE_KEY);
 };

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -149,6 +149,10 @@ const ProfilePage = () => {
       return;
     }
 
+    if (newPassword !== confirmNewPassword) {
+      return;
+    }
+
     try {
       await updateUserPassword(password.oldPassword, password.newPassword);
       setSuccessModal({
@@ -313,7 +317,8 @@ const ProfilePage = () => {
                   disabled={
                     password.oldPassword === "" ||
                     password.newPassword === "" ||
-                    password.confirmNewPassword === ""
+                    password.confirmNewPassword === "" ||
+                    password.newPassword !== password.confirmNewPassword
                   }
                   onClick={handleUpdatePassword}
                 />

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -22,7 +22,7 @@ interface Profile {
 }
 
 const ProfilePage = () => {
-  const { deauthenticate } = useAuth();
+  const { authenticate, deauthenticate } = useAuth();
   const { handleApiError } = useError();
   const [successModal, setSuccessModal] = useState({
     isOpen: false,
@@ -93,13 +93,16 @@ const ProfilePage = () => {
 
   const handleUpdateProfile = async () => {
     try {
-      await updateUserProfile({ nickname: profile.nickname });
+      const updatedUser = await updateUserProfile({
+        nickname: profile.nickname,
+      });
       setSuccessModal({
         isOpen: true,
         message: "Your profile has been successfully updated.",
         onClose: () =>
           setSuccessModal({ isOpen: false, message: "", onClose: () => {} }),
       });
+      authenticate({ id: updatedUser.id, nickname: updatedUser.nickname });
     } catch (error) {
       if (error instanceof ApiError) {
         handleApiError(error);

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -1,5 +1,285 @@
+import { useEffect, useState } from "react";
+import { styled } from "styled-components";
+
+import Header from "../../components/organisms/Header";
+import BasicButton from "../../components/atoms/BasicButton";
+import LoadingScreen from "../../components/organisms/LoadingScreen";
+
+interface Profile {
+  email: string;
+  nickname: string;
+}
+
 const ProfilePage = () => {
-  return <h1>profile</h1>;
+  const [isLoading, setIsLoading] = useState(false);
+  const [hidden, setHidden] = useState({
+    updatePassword: true,
+    deleteAccount: true,
+  });
+  const [profile, setProfile] = useState<Profile>({
+    email: "",
+    nickname: "",
+  });
+  const [password, setPassword] = useState({
+    oldPassword: "",
+    newPassword: "",
+    confirmNewPassword: "",
+  });
+
+  // === profile ===
+  const handleChangeProfileInput = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name, value } = event.target;
+
+    if (name === "email") {
+      setProfile({ ...profile, email: value });
+    } else if (name === "nickname") {
+      setProfile({ ...profile, nickname: value });
+    } else {
+      return;
+    }
+  };
+
+  const handleUpdateProfile = () => {
+    // TODO: 회원 정보 변경 API 연동
+  };
+
+  // === update password ===
+  const handleChangePasswordInput = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name, value } = event.target;
+
+    if (name === "oldPassword") {
+      setPassword({ ...password, oldPassword: value });
+    } else if (name === "newPassword") {
+      setPassword({ ...password, newPassword: value });
+    } else if (name === "confirmNewPassword") {
+      setPassword({ ...password, confirmNewPassword: value });
+    } else {
+      return;
+    }
+  };
+
+  const handleUpdatePassword = () => {
+    // TODO: 비밀번호 변경 API 연동
+  };
+
+  // === delete account ===
+  const handleDeleteAccount = () => {
+    // TODO: 회원 탈퇴 API 연동
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      // TODO: 사용자 조회 API 연동
+      const user: { id: string; email: string; nickname: string } =
+        await new Promise((resolve) =>
+          resolve({
+            id: "test",
+            email: "test@email.com",
+            nickname: "test_nickname",
+          })
+        );
+      setProfile({ email: user.email, nickname: user.nickname });
+    };
+
+    fetchData();
+  }, []);
+
+  if (isLoading) {
+    return <LoadingScreen />;
+  }
+
+  return (
+    <Wrapper>
+      <Header title="Edit Profile" description="Edit your information." />
+      <ScrollableWrapper>
+        <Container>
+          <SubTitle>Profile</SubTitle>
+          <Input type="text" name="email" value={profile.email} disabled />
+          <Input
+            type="text"
+            name="nickname"
+            placeholder="Nickname"
+            value={profile.nickname}
+            onChange={handleChangeProfileInput}
+          />
+          <ButtonWrapper>
+            <BasicButton
+              label="Update profile"
+              size="small"
+              type="confirm"
+              onClick={handleUpdateProfile}
+            />
+          </ButtonWrapper>
+        </Container>
+        <Container>
+          <SubTitle>Password</SubTitle>
+          {!hidden.updatePassword && (
+            <>
+              <Input
+                type="password"
+                name="oldPassword"
+                placeholder="Old password"
+                value={password.oldPassword}
+                onChange={handleChangePasswordInput}
+              />
+              <Input
+                type="password"
+                name="newPassword"
+                placeholder="New password"
+                value={password.newPassword}
+                onChange={handleChangePasswordInput}
+              />
+              <Input
+                type="password"
+                name="confirmNewPassword"
+                placeholder="Confirm new password"
+                value={password.confirmNewPassword}
+                onChange={handleChangePasswordInput}
+              />
+            </>
+          )}
+          <ButtonWrapper>
+            <BasicButton
+              label={hidden.updatePassword ? "Show" : "Hide"}
+              size="small"
+              type={hidden.updatePassword ? "confirm" : "cancel"}
+              onClick={() =>
+                setHidden({ ...hidden, updatePassword: !hidden.updatePassword })
+              }
+            />
+            {!hidden.updatePassword && (
+              <BasicButton
+                label="Update password"
+                size="small"
+                type="confirm"
+                onClick={handleUpdatePassword}
+              />
+            )}
+          </ButtonWrapper>
+        </Container>
+        <Container>
+          <SubTitle className="delete-account">Delete Account</SubTitle>
+          <DeleteAccountDescription>
+            <span>Warning: Deleting your account is permanent. </span>Once your
+            account is deleted, all your data will be lost and cannot be
+            recovered. Please make sure you want to proceed before taking this
+            action.
+          </DeleteAccountDescription>
+          {!hidden.deleteAccount && (
+            <>
+              <p>test</p>
+            </>
+          )}
+          <ButtonWrapper>
+            <BasicButton
+              label={hidden.deleteAccount ? "Show" : "Hide"}
+              size="small"
+              type={hidden.deleteAccount ? "danger" : "cancel"}
+              onClick={() =>
+                setHidden({ ...hidden, deleteAccount: !hidden.deleteAccount })
+              }
+            />
+            {!hidden.deleteAccount && (
+              <BasicButton
+                label="Delete your account"
+                size="small"
+                type="danger"
+                onClick={handleDeleteAccount}
+              />
+            )}
+          </ButtonWrapper>
+        </Container>
+      </ScrollableWrapper>
+    </Wrapper>
+  );
 };
 
 export default ProfilePage;
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  padding-left: 30px;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ScrollableWrapper = styled.div`
+  flex: 1;
+  overflow-y: auto;
+`;
+
+export const Container = styled.div`
+  width: 50%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 40px;
+`;
+
+export const SubTitle = styled.label`
+  display: inline-block;
+  font-size: 20px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.text.accent};
+
+  &.delete-account {
+    color: ${({ theme }) => theme.text.danger};
+  }
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  padding: 16px 20px;
+  border-radius: 50px;
+  border: 2px solid ${({ theme }) => theme.button.secondary};
+  outline: none;
+  font-size: 16px;
+
+  &:focus {
+    border: 2px solid ${({ theme }) => theme.button.primary};
+  }
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.button.secondary};
+  }
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+`;
+
+export const DeleteAccountDescription = styled.p`
+  color: ${({ theme }) => theme.text.secondary};
+  line-height: 1.2;
+
+  span {
+    font-weight: 600;
+  }
+`;
+
+export const ModalInput = styled.input`
+  width: 100%;
+  padding: 8px 0;
+  border: none;
+  border-bottom: 2px solid ${({ theme }) => theme.text.tertiary};
+  outline: none;
+  font-size: 16px;
+  text-align: center;
+
+  &:focus {
+    border-bottom: 2px solid ${({ theme }) => theme.text.accent};
+
+    &::placeholder {
+      opacity: 0; /* 포커스 시 placeholder 숨김 */
+    }
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.text.tertiary};
+  }
+`;

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -4,6 +4,14 @@ import * as S from "./style";
 import Header from "../../components/organisms/Header";
 import BasicButton from "../../components/atoms/BasicButton";
 import LoadingScreen from "../../components/organisms/LoadingScreen";
+import {
+  getUser,
+  updateUserPassword,
+  updateUserProfile,
+} from "../../apis/user";
+import Modal from "../../components/organisms/Modal";
+import { useError } from "../../contexts/error";
+import { ApiError } from "../../types/errorTypes";
 
 const CONFIRMATION_PHRASE = "delete my account";
 
@@ -13,9 +21,14 @@ interface Profile {
 }
 
 const ProfilePage = () => {
+  const { handleApiError } = useError();
   const [isLoading, setIsLoading] = useState(false);
+  const [modal, setModal] = useState({
+    isOpen: false,
+    message: "",
+  });
   const [hidden, setHidden] = useState({
-    updatePassword: true,
+    updatePassword: false,
     deleteAccount: true,
   });
   const [profile, setProfile] = useState<Profile>({
@@ -31,6 +44,21 @@ const ProfilePage = () => {
     email: "",
     phrase: "",
   });
+  const [errors, setErrors] = useState({
+    profile: {
+      email: "",
+      nickname: "",
+    },
+    password: {
+      oldPassword: "",
+      newPassword: "",
+      confirmNewPassword: "",
+    },
+    deleteAccount: {
+      email: "",
+      phrase: "",
+    },
+  });
 
   // === profile ===
   const handleChangeProfileInput = (
@@ -43,10 +71,32 @@ const ProfilePage = () => {
     } else {
       return;
     }
+    // TODO: 비밀번호 규칙 설정
+
+    setErrors({
+      ...errors,
+      profile: {
+        ...errors.profile,
+        nickname:
+          value.length < 2
+            ? "Your nickname must be at least 2 characters long."
+            : "",
+      },
+    });
   };
 
-  const handleUpdateProfile = () => {
-    // TODO: 회원 정보 변경 API 연동
+  const handleUpdateProfile = async () => {
+    try {
+      await updateUserProfile({ nickname: profile.nickname });
+      setModal({
+        isOpen: true,
+        message: "Your profile has been successfully updated.",
+      });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        handleApiError(error);
+      }
+    }
   };
 
   // === update password ===
@@ -54,20 +104,56 @@ const ProfilePage = () => {
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
     const { name, value } = event.target;
+    let isMatched = false;
 
     if (name === "oldPassword") {
       setPassword({ ...password, oldPassword: value });
     } else if (name === "newPassword") {
       setPassword({ ...password, newPassword: value });
+      isMatched = value === password.confirmNewPassword;
     } else if (name === "confirmNewPassword") {
       setPassword({ ...password, confirmNewPassword: value });
+      isMatched = value === password.newPassword;
     } else {
       return;
     }
+
+    if (name === "newPassword" || name === "confirmNewPassword") {
+      setErrors({
+        ...errors,
+        password: {
+          ...errors.password,
+          confirmNewPassword: isMatched
+            ? ""
+            : "The new password and confirmation password do not match.",
+        },
+      });
+    }
   };
 
-  const handleUpdatePassword = () => {
-    // TODO: 비밀번호 변경 API 연동
+  const handleUpdatePassword = async () => {
+    const { oldPassword, newPassword, confirmNewPassword } = password;
+
+    if (oldPassword === "" || newPassword === "" || confirmNewPassword === "") {
+      return;
+    }
+
+    try {
+      await updateUserPassword(password.oldPassword, password.newPassword);
+      setModal({
+        isOpen: true,
+        message: "Your password has been successfully changed.",
+      });
+      setPassword({
+        oldPassword: "",
+        newPassword: "",
+        confirmNewPassword: "",
+      });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        handleApiError(error);
+      }
+    }
   };
 
   // === delete account ===
@@ -89,15 +175,7 @@ const ProfilePage = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      // TODO: 사용자 조회 API 연동
-      const user: { id: string; email: string; nickname: string } =
-        await new Promise((resolve) =>
-          resolve({
-            id: "test",
-            email: "test@email.com",
-            nickname: "test_nickname",
-          })
-        );
+      const user = await getUser();
       setProfile({ email: user.email, nickname: user.nickname });
     };
 
@@ -109,137 +187,198 @@ const ProfilePage = () => {
   }
 
   return (
-    <S.Wrapper>
-      <Header title="Edit Profile" description="Edit your information." />
-      <S.ScrollableWrapper>
-        <S.Container>
-          <S.SubTitle>Profile</S.SubTitle>
-          <S.Input
-            type="text"
-            name="profileEmail"
-            value={profile.email}
-            disabled
-          />
-          <S.Input
-            type="text"
-            name="nickname"
-            placeholder="Nickname"
-            value={profile.nickname}
-            onChange={handleChangeProfileInput}
-          />
-          <S.ButtonWrapper>
-            <BasicButton
-              label="Update profile"
-              size="small"
-              type="confirm"
-              onClick={handleUpdateProfile}
-            />
-          </S.ButtonWrapper>
-        </S.Container>
-        <S.Container>
-          <S.SubTitle>Password</S.SubTitle>
-          {!hidden.updatePassword && (
-            <>
+    <>
+      <S.Wrapper>
+        <Header title="Edit Profile" description="Edit your information." />
+        <S.ScrollableWrapper>
+          {/* ⭐️ Profile ⭐️ */}
+          <S.Container>
+            <S.SubTitle>Profile</S.SubTitle>
+            <S.InputWrapper>
               <S.Input
-                type="password"
-                name="oldPassword"
-                placeholder="Old password"
-                value={password.oldPassword}
-                onChange={handleChangePasswordInput}
+                type="text"
+                name="profileEmail"
+                value={profile.email}
+                disabled
+                $error={!!errors.profile.email}
               />
+              <S.ErrorText>{errors.profile.email}</S.ErrorText>
+            </S.InputWrapper>
+            <S.InputWrapper>
               <S.Input
-                type="password"
-                name="newPassword"
-                placeholder="New password"
-                value={password.newPassword}
-                onChange={handleChangePasswordInput}
+                type="text"
+                name="nickname"
+                placeholder="Nickname"
+                value={profile.nickname}
+                onChange={handleChangeProfileInput}
+                $error={!!errors.profile.nickname}
               />
-              <S.Input
-                type="password"
-                name="confirmNewPassword"
-                placeholder="Confirm new password"
-                value={password.confirmNewPassword}
-                onChange={handleChangePasswordInput}
-              />
-            </>
-          )}
-          <S.ButtonWrapper>
-            <BasicButton
-              label={hidden.updatePassword ? "Show" : "Hide"}
-              size="small"
-              type={hidden.updatePassword ? "confirm" : "cancel"}
-              onClick={() =>
-                setHidden({ ...hidden, updatePassword: !hidden.updatePassword })
-              }
-            />
-            {!hidden.updatePassword && (
+              <S.ErrorText>{errors.profile.nickname}</S.ErrorText>
+            </S.InputWrapper>
+            <S.ButtonWrapper>
               <BasicButton
-                label="Update password"
+                label="Update profile"
                 size="small"
                 type="confirm"
-                onClick={handleUpdatePassword}
+                onClick={handleUpdateProfile}
+                disabled={profile.nickname.length < 2}
               />
+            </S.ButtonWrapper>
+          </S.Container>
+          {/* ⭐️ Password ⭐️ */}
+          <S.Container>
+            <S.SubTitle>Password</S.SubTitle>
+            {!hidden.updatePassword && (
+              <>
+                <S.InputWrapper>
+                  <S.Input
+                    type="password"
+                    name="oldPassword"
+                    placeholder="Old password"
+                    value={password.oldPassword}
+                    onChange={handleChangePasswordInput}
+                    $error={!!errors.password.oldPassword}
+                  />
+
+                  <S.ErrorText>{errors.password.oldPassword}</S.ErrorText>
+                </S.InputWrapper>
+                <S.InputWrapper>
+                  <S.Input
+                    type="password"
+                    name="newPassword"
+                    placeholder="New password"
+                    value={password.newPassword}
+                    onChange={handleChangePasswordInput}
+                    $error={!!errors.password.newPassword}
+                  />
+
+                  <S.ErrorText>{errors.password.newPassword}</S.ErrorText>
+                </S.InputWrapper>
+                <S.InputWrapper>
+                  <S.Input
+                    type="password"
+                    name="confirmNewPassword"
+                    placeholder="Confirm new password"
+                    value={password.confirmNewPassword}
+                    onChange={handleChangePasswordInput}
+                    $error={!!errors.password.confirmNewPassword}
+                  />
+
+                  <S.ErrorText>
+                    {errors.password.confirmNewPassword}
+                  </S.ErrorText>
+                </S.InputWrapper>
+              </>
             )}
-          </S.ButtonWrapper>
-        </S.Container>
-        <S.Container>
-          <S.SubTitle className="delete-account">Delete Account</S.SubTitle>
-          <p>
-            <span>Warning: Deleting your account is permanent. </span>Once your
-            account is deleted, all your data will be lost and cannot be
-            recovered. Please make sure you want to proceed before taking this
-            action.
-          </p>
-          {!hidden.deleteAccount && (
-            <>
-              <p>
-                <span>Are you sure you want to delete your account?</span>
-              </p>
-              <p>Your email : </p>
-              <S.Input
-                type="text"
-                name="deleteAccountEmail"
-                value={deleteAccount.email}
-                placeholder="Email"
-                onChange={handleDeleteAccountInput}
-              />
-              <p>
-                To verify, type{" "}
-                <span>
-                  <i>"{CONFIRMATION_PHRASE}"</i>
-                </span>{" "}
-                below:
-              </p>
-              <S.Input
-                type="text"
-                name="confirmationPhrase"
-                value={deleteAccount.phrase}
-                placeholder="Confirmation phrase"
-                onChange={handleDeleteAccountInput}
-              />
-            </>
-          )}
-          <S.ButtonWrapper>
-            <BasicButton
-              label={hidden.deleteAccount ? "Show" : "Hide"}
-              size="small"
-              type={hidden.deleteAccount ? "danger" : "cancel"}
-              onClick={() =>
-                setHidden({ ...hidden, deleteAccount: !hidden.deleteAccount })
-              }
-            />
-            {!hidden.deleteAccount && (
+            <S.ButtonWrapper>
               <BasicButton
-                label="Delete your account"
+                label={hidden.updatePassword ? "Show" : "Hide"}
                 size="small"
-                type="danger"
-                onClick={handleDeleteAccount}
+                type={hidden.updatePassword ? "confirm" : "default"}
+                onClick={() =>
+                  setHidden({
+                    ...hidden,
+                    updatePassword: !hidden.updatePassword,
+                  })
+                }
               />
+              {!hidden.updatePassword && (
+                <BasicButton
+                  label="Update password"
+                  size="small"
+                  type="confirm"
+                  disabled={
+                    password.oldPassword === "" ||
+                    password.newPassword === "" ||
+                    password.confirmNewPassword === ""
+                  }
+                  onClick={handleUpdatePassword}
+                />
+              )}
+            </S.ButtonWrapper>
+          </S.Container>
+          {/* ⭐️ Delete Account ⭐️ */}
+          <S.Container>
+            <S.SubTitle className="delete-account">Delete Account</S.SubTitle>
+            <p>
+              <span>Warning: Deleting your account is permanent. </span>Once
+              your account is deleted, all your data will be lost and cannot be
+              recovered. Please make sure you want to proceed before taking this
+              action.
+            </p>
+            {!hidden.deleteAccount && (
+              <>
+                <p>
+                  <span>Are you sure you want to delete your account?</span>
+                </p>
+                <p>Your email : </p>
+                <S.Input
+                  type="text"
+                  name="deleteAccountEmail"
+                  value={deleteAccount.email}
+                  placeholder="Email"
+                  onChange={handleDeleteAccountInput}
+                  $error={!!errors.deleteAccount.email}
+                />
+                <p>
+                  To verify, type{" "}
+                  <span>
+                    <i>"{CONFIRMATION_PHRASE}"</i>
+                  </span>{" "}
+                  below:
+                </p>
+                <S.Input
+                  type="text"
+                  name="confirmationPhrase"
+                  value={deleteAccount.phrase}
+                  placeholder="Confirmation phrase"
+                  onChange={handleDeleteAccountInput}
+                  $error={!!errors.deleteAccount.email}
+                />
+                {errors.deleteAccount.phrase && (
+                  <S.ErrorText>{errors.deleteAccount.phrase}</S.ErrorText>
+                )}
+              </>
             )}
-          </S.ButtonWrapper>
-        </S.Container>
-      </S.ScrollableWrapper>
-    </S.Wrapper>
+            <S.ButtonWrapper>
+              <BasicButton
+                label={hidden.deleteAccount ? "Show" : "Hide"}
+                size="small"
+                type={hidden.deleteAccount ? "danger" : "default"}
+                onClick={() =>
+                  setHidden({ ...hidden, deleteAccount: !hidden.deleteAccount })
+                }
+              />
+              {!hidden.deleteAccount && (
+                <BasicButton
+                  label="Delete your account"
+                  size="small"
+                  type="danger"
+                  onClick={handleDeleteAccount}
+                  disabled={
+                    deleteAccount.email === "" || deleteAccount.phrase === ""
+                  }
+                />
+              )}
+            </S.ButtonWrapper>
+          </S.Container>
+        </S.ScrollableWrapper>
+      </S.Wrapper>
+      {modal.isOpen && (
+        <Modal
+          type="success"
+          buttons={[
+            {
+              label: "OK",
+              location: "center",
+              onClick: () => setModal({ isOpen: false, message: "" }),
+            },
+          ]}
+        >
+          <p style={{ lineHeight: "1.5" }}>{modal.message}</p>
+        </Modal>
+      )}
+    </>
   );
 };
 

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { styled } from "styled-components";
 
+import * as S from "./style";
 import Header from "../../components/organisms/Header";
 import BasicButton from "../../components/atoms/BasicButton";
 import LoadingScreen from "../../components/organisms/LoadingScreen";
@@ -93,47 +93,47 @@ const ProfilePage = () => {
   }
 
   return (
-    <Wrapper>
+    <S.Wrapper>
       <Header title="Edit Profile" description="Edit your information." />
-      <ScrollableWrapper>
-        <Container>
-          <SubTitle>Profile</SubTitle>
-          <Input type="text" name="email" value={profile.email} disabled />
-          <Input
+      <S.ScrollableWrapper>
+        <S.Container>
+          <S.SubTitle>Profile</S.SubTitle>
+          <S.Input type="text" name="email" value={profile.email} disabled />
+          <S.Input
             type="text"
             name="nickname"
             placeholder="Nickname"
             value={profile.nickname}
             onChange={handleChangeProfileInput}
           />
-          <ButtonWrapper>
+          <S.ButtonWrapper>
             <BasicButton
               label="Update profile"
               size="small"
               type="confirm"
               onClick={handleUpdateProfile}
             />
-          </ButtonWrapper>
-        </Container>
-        <Container>
-          <SubTitle>Password</SubTitle>
+          </S.ButtonWrapper>
+        </S.Container>
+        <S.Container>
+          <S.SubTitle>Password</S.SubTitle>
           {!hidden.updatePassword && (
             <>
-              <Input
+              <S.Input
                 type="password"
                 name="oldPassword"
                 placeholder="Old password"
                 value={password.oldPassword}
                 onChange={handleChangePasswordInput}
               />
-              <Input
+              <S.Input
                 type="password"
                 name="newPassword"
                 placeholder="New password"
                 value={password.newPassword}
                 onChange={handleChangePasswordInput}
               />
-              <Input
+              <S.Input
                 type="password"
                 name="confirmNewPassword"
                 placeholder="Confirm new password"
@@ -142,7 +142,7 @@ const ProfilePage = () => {
               />
             </>
           )}
-          <ButtonWrapper>
+          <S.ButtonWrapper>
             <BasicButton
               label={hidden.updatePassword ? "Show" : "Hide"}
               size="small"
@@ -159,22 +159,22 @@ const ProfilePage = () => {
                 onClick={handleUpdatePassword}
               />
             )}
-          </ButtonWrapper>
-        </Container>
-        <Container>
-          <SubTitle className="delete-account">Delete Account</SubTitle>
-          <DeleteAccountDescription>
+          </S.ButtonWrapper>
+        </S.Container>
+        <S.Container>
+          <S.SubTitle className="delete-account">Delete Account</S.SubTitle>
+          <S.DeleteAccountDescription>
             <span>Warning: Deleting your account is permanent. </span>Once your
             account is deleted, all your data will be lost and cannot be
             recovered. Please make sure you want to proceed before taking this
             action.
-          </DeleteAccountDescription>
+          </S.DeleteAccountDescription>
           {!hidden.deleteAccount && (
             <>
               <p>test</p>
             </>
           )}
-          <ButtonWrapper>
+          <S.ButtonWrapper>
             <BasicButton
               label={hidden.deleteAccount ? "Show" : "Hide"}
               size="small"
@@ -191,95 +191,11 @@ const ProfilePage = () => {
                 onClick={handleDeleteAccount}
               />
             )}
-          </ButtonWrapper>
-        </Container>
-      </ScrollableWrapper>
-    </Wrapper>
+          </S.ButtonWrapper>
+        </S.Container>
+      </S.ScrollableWrapper>
+    </S.Wrapper>
   );
 };
 
 export default ProfilePage;
-
-export const Wrapper = styled.div`
-  width: 100%;
-  height: 100%;
-  padding-left: 30px;
-  display: flex;
-  flex-direction: column;
-`;
-
-export const ScrollableWrapper = styled.div`
-  flex: 1;
-  overflow-y: auto;
-`;
-
-export const Container = styled.div`
-  width: 50%;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  margin-top: 40px;
-`;
-
-export const SubTitle = styled.label`
-  display: inline-block;
-  font-size: 20px;
-  font-weight: 700;
-  color: ${({ theme }) => theme.text.accent};
-
-  &.delete-account {
-    color: ${({ theme }) => theme.text.danger};
-  }
-`;
-
-export const Input = styled.input`
-  width: 100%;
-  padding: 16px 20px;
-  border-radius: 50px;
-  border: 2px solid ${({ theme }) => theme.button.secondary};
-  outline: none;
-  font-size: 16px;
-
-  &:focus {
-    border: 2px solid ${({ theme }) => theme.button.primary};
-  }
-
-  &:disabled {
-    background-color: ${({ theme }) => theme.button.secondary};
-  }
-`;
-
-export const ButtonWrapper = styled.div`
-  display: flex;
-`;
-
-export const DeleteAccountDescription = styled.p`
-  color: ${({ theme }) => theme.text.secondary};
-  line-height: 1.2;
-
-  span {
-    font-weight: 600;
-  }
-`;
-
-export const ModalInput = styled.input`
-  width: 100%;
-  padding: 8px 0;
-  border: none;
-  border-bottom: 2px solid ${({ theme }) => theme.text.tertiary};
-  outline: none;
-  font-size: 16px;
-  text-align: center;
-
-  &:focus {
-    border-bottom: 2px solid ${({ theme }) => theme.text.accent};
-
-    &::placeholder {
-      opacity: 0; /* 포커스 시 placeholder 숨김 */
-    }
-  }
-
-  &::placeholder {
-    color: ${({ theme }) => theme.text.tertiary};
-  }
-`;

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -5,6 +5,8 @@ import Header from "../../components/organisms/Header";
 import BasicButton from "../../components/atoms/BasicButton";
 import LoadingScreen from "../../components/organisms/LoadingScreen";
 
+const CONFIRMATION_PHRASE = "delete my account";
+
 interface Profile {
   email: string;
   nickname: string;
@@ -25,6 +27,10 @@ const ProfilePage = () => {
     newPassword: "",
     confirmNewPassword: "",
   });
+  const [deleteAccount, setDeleteAccount] = useState({
+    email: "",
+    phrase: "",
+  });
 
   // === profile ===
   const handleChangeProfileInput = (
@@ -32,9 +38,7 @@ const ProfilePage = () => {
   ) => {
     const { name, value } = event.target;
 
-    if (name === "email") {
-      setProfile({ ...profile, email: value });
-    } else if (name === "nickname") {
+    if (name === "nickname") {
       setProfile({ ...profile, nickname: value });
     } else {
       return;
@@ -67,6 +71,18 @@ const ProfilePage = () => {
   };
 
   // === delete account ===
+  const handleDeleteAccountInput = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name, value } = event.target;
+
+    if (name === "deleteAccountEmail") {
+      setDeleteAccount({ ...deleteAccount, email: value });
+    } else if (name === "confirmationPhrase") {
+      setDeleteAccount({ ...deleteAccount, phrase: value });
+    }
+  };
+
   const handleDeleteAccount = () => {
     // TODO: 회원 탈퇴 API 연동
   };
@@ -98,7 +114,12 @@ const ProfilePage = () => {
       <S.ScrollableWrapper>
         <S.Container>
           <S.SubTitle>Profile</S.SubTitle>
-          <S.Input type="text" name="email" value={profile.email} disabled />
+          <S.Input
+            type="text"
+            name="profileEmail"
+            value={profile.email}
+            disabled
+          />
           <S.Input
             type="text"
             name="nickname"
@@ -163,15 +184,39 @@ const ProfilePage = () => {
         </S.Container>
         <S.Container>
           <S.SubTitle className="delete-account">Delete Account</S.SubTitle>
-          <S.DeleteAccountDescription>
+          <p>
             <span>Warning: Deleting your account is permanent. </span>Once your
             account is deleted, all your data will be lost and cannot be
             recovered. Please make sure you want to proceed before taking this
             action.
-          </S.DeleteAccountDescription>
+          </p>
           {!hidden.deleteAccount && (
             <>
-              <p>test</p>
+              <p>
+                <span>Are you sure you want to delete your account?</span>
+              </p>
+              <p>Your email : </p>
+              <S.Input
+                type="text"
+                name="deleteAccountEmail"
+                value={deleteAccount.email}
+                placeholder="Email"
+                onChange={handleDeleteAccountInput}
+              />
+              <p>
+                To verify, type{" "}
+                <span>
+                  <i>"{CONFIRMATION_PHRASE}"</i>
+                </span>{" "}
+                below:
+              </p>
+              <S.Input
+                type="text"
+                name="confirmationPhrase"
+                value={deleteAccount.phrase}
+                placeholder="Confirmation phrase"
+                onChange={handleDeleteAccountInput}
+              />
             </>
           )}
           <S.ButtonWrapper>

--- a/src/pages/ProfilePage/style.ts
+++ b/src/pages/ProfilePage/style.ts
@@ -18,10 +18,23 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
-  margin-top: 40px;
+  margin: 40px 0px 60px 0px;
+
+  p {
+    line-height: 1.2;
+    color: ${({ theme }) => theme.text.secondary};
+  }
+
+  span {
+    font-weight: 600;
+  }
+
+  i {
+    font-style: italic;
+  }
 `;
 
-export const SubTitle = styled.label`
+export const SubTitle = styled.h1`
   display: inline-block;
   font-size: 20px;
   font-weight: 700;

--- a/src/pages/ProfilePage/style.ts
+++ b/src/pages/ProfilePage/style.ts
@@ -1,0 +1,85 @@
+import { styled } from "styled-components";
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  padding-left: 30px;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ScrollableWrapper = styled.div`
+  flex: 1;
+  overflow-y: auto;
+`;
+
+export const Container = styled.div`
+  width: 50%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 40px;
+`;
+
+export const SubTitle = styled.label`
+  display: inline-block;
+  font-size: 20px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.text.accent};
+
+  &.delete-account {
+    color: ${({ theme }) => theme.text.danger};
+  }
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  padding: 16px 20px;
+  border-radius: 50px;
+  border: 2px solid ${({ theme }) => theme.button.secondary};
+  outline: none;
+  font-size: 16px;
+
+  &:focus {
+    border: 2px solid ${({ theme }) => theme.button.primary};
+  }
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.button.secondary};
+  }
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+`;
+
+export const DeleteAccountDescription = styled.p`
+  color: ${({ theme }) => theme.text.secondary};
+  line-height: 1.2;
+
+  span {
+    font-weight: 600;
+  }
+`;
+
+export const ModalInput = styled.input`
+  width: 100%;
+  padding: 8px 0;
+  border: none;
+  border-bottom: 2px solid ${({ theme }) => theme.text.tertiary};
+  outline: none;
+  font-size: 16px;
+  text-align: center;
+
+  &:focus {
+    border-bottom: 2px solid ${({ theme }) => theme.text.accent};
+
+    &::placeholder {
+      opacity: 0; /* 포커스 시 placeholder 숨김 */
+    }
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.text.tertiary};
+  }
+`;

--- a/src/pages/ProfilePage/style.ts
+++ b/src/pages/ProfilePage/style.ts
@@ -45,21 +45,33 @@ export const SubTitle = styled.h1`
   }
 `;
 
-export const Input = styled.input`
+export const InputWrapper = styled.div``;
+
+export const Input = styled.input<{ $error: boolean }>`
   width: 100%;
   padding: 16px 20px;
   border-radius: 50px;
-  border: 2px solid ${({ theme }) => theme.button.secondary};
+  border: 2px solid
+    ${({ theme, $error }) =>
+      $error ? theme.button.danger : theme.button.secondary};
   outline: none;
   font-size: 16px;
 
   &:focus {
-    border: 2px solid ${({ theme }) => theme.button.primary};
+    border: 2px solid
+      ${({ theme, $error }) =>
+        $error ? theme.button.danger : theme.button.primary};
   }
 
   &:disabled {
     background-color: ${({ theme }) => theme.button.secondary};
   }
+`;
+
+export const ErrorText = styled.p`
+  color: ${({ theme }) => theme.text.danger} !important;
+  font-size: 14px;
+  margin: 8px;
 `;
 
 export const ButtonWrapper = styled.div`


### PR DESCRIPTION
## 🚀 이슈 번호
#15 
<br>

## 💡 변경 이유
- 사용자 페이지 UI 구현
- 사용자 페이지 API 연동
<br>

## 🔑 주요 변경사항

- 사용자 프로필 페이지
  - 프로필 변경(현재는 닉네임 변경만 지원)
    - 회원 개인만 보는 닉네임이므로 중복 허용
    - 2자 이상으로 설정 가능
  - 비밀번호 변경
    - 사용자의 주의를 요하는 작업이므로 펼치기/접기 기능을 넣어 단순하게 비밀번호를 수정하지 않도록 하였음
    - 모든 input이 입력되고, 확인 비밀번호와 일치할 경우 update 버튼이 활성화됨
    - 이전 비밀번호가 일치하지 않을 경우 오류 발생
  - 회원 탈퇴
    - 사용자의 주의를 요하는 작업이므로 펼치기/접기 기능을 넣어 단순하게 탈퇴하지 않도록 하였음
    - 모든 input이 입력되고 확인 문구가 일치할 경우 delete 버튼이 활성화됨
    - 이메일이 일치하지 않을 경우 오류 발생
  - api 연동
    - 사용자 프로필 수정
    - 사용자 비밀번호 수정
    - 회원탈퇴
    - 사용자 조회

## 앞으로 남은 작업
- [ ] 비밀번호 규칙 정하기

<br>

## 📷 테스트 결과

https://github.com/user-attachments/assets/09189569-9dce-4ba8-b24d-a6a3095053c8

https://github.com/user-attachments/assets/6c8ba558-a010-4b26-9077-27fa43d1ff1e

https://github.com/user-attachments/assets/0f31f587-a151-46e0-8458-f8a127794d27

